### PR TITLE
fix(schema): allow domains to share a landing directory when table patterns are disjoint

### DIFF
--- a/src/main/scala/ai/starlake/schema/handlers/SchemaHandler.scala
+++ b/src/main/scala/ai/starlake/schema/handlers/SchemaHandler.scala
@@ -1033,20 +1033,10 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
       case Left(errors) =>
         errors
     }
-    val directoryErrors = Utils.duplicates(
-      "Domain directory",
-      nonEmptyDomains.flatMap(_.resolveDirectoryOpt()),
-      s"%s is defined %d times. A directory can only appear once in a domain definition file."
-    ) match {
-      case Right(_) =>
-        if (!raw) {
-          this._domains = Some(nonEmptyDomains)
-          DatasetArea.initDomains(storage, nonEmptyDomains.map(_.name))
-
-        }
-        Nil
-      case Left(errors) =>
-        errors
+    val directoryErrors = checkDomainDirectories(nonEmptyDomains)
+    if (nameErrors.isEmpty && directoryErrors.isEmpty && !raw) {
+      this._domains = Some(nonEmptyDomains)
+      DatasetArea.initDomains(storage, nonEmptyDomains.map(_.name))
     }
 
     invalidDomainsFiles.foreach {
@@ -1059,6 +1049,56 @@ class SchemaHandler(storage: StorageHandler, cliEnv: Map[String, String] = Map.e
     this._domainErrors = nameErrors ++ directoryErrors
     this._domainErrors.foreach(err => logger.error(err.toString()))
     (this._domainErrors, nonEmptyDomains)
+  }
+
+  /** Several domains may share the same landing directory (managed file-receiver pattern: an
+    * upstream system drops the files of many functional domains into a single directory) provided
+    * routing a file to a table stays deterministic. Determinism is checked textually: a table
+    * filename pattern declared verbatim by more than one table of the sharing domains is rejected.
+    * Patterns that differ as strings but still match the same filenames (e.g. "clients-.*" vs ".*")
+    * cannot be detected here; keeping the shared patterns effectively disjoint remains the user's
+    * responsibility, hence the warning logged on the accept path.
+    */
+  private def checkDomainDirectories(
+    domains: List[DomainInfo]
+  ): List[ValidationMessage] = {
+    val sharedDirectories =
+      domains
+        .flatMap(domain => domain.resolveDirectoryOpt().map(_ -> domain))
+        .groupMap { case (directory, _) => directory } { case (_, domain) => domain }
+        .filter { case (_, sharingDomains) => sharingDomains.size > 1 }
+        .toList
+        .sortBy { case (directory, _) => directory }
+    sharedDirectories.flatMap { case (directory, sharingDomains) =>
+      val declaringDomainsByPattern =
+        sharingDomains
+          .flatMap(domain => domain.tables.map(table => table.pattern.pattern() -> domain.name))
+          .groupMap { case (pattern, _) => pattern } { case (_, domainName) => domainName }
+      val duplicatedPatterns =
+        declaringDomainsByPattern
+          .filter { case (_, declaringDomains) => declaringDomains.size > 1 }
+          .toList
+          .sortBy { case (pattern, _) => pattern }
+      if (duplicatedPatterns.isEmpty) {
+        logger.warn(
+          s"Domain directory $directory is shared by domains ${sharingDomains.map(_.name).sorted.mkString(", ")}. " +
+          s"No table filename pattern is declared twice across them, but make sure their patterns are effectively disjoint: " +
+          s"a file matching tables of several domains would make its routing non-deterministic."
+        )
+        Nil
+      } else {
+        duplicatedPatterns.map { case (pattern, declaringDomains) =>
+          ValidationMessage(
+            Error,
+            "Domain directory",
+            s"$directory is shared by domains ${sharingDomains.map(_.name).sorted.mkString(", ")} and the table pattern '$pattern' " +
+            s"is declared by ${declaringDomains.size} tables (in domain(s) ${declaringDomains.distinct.sorted
+                .mkString(", ")}). " +
+            s"Domains may share a directory only when their table filename patterns are disjoint."
+          )
+        }
+      }
+    }
   }
 
   private def loadDomains(

--- a/src/test/resources/sample/shared-directory/clients.sl.yml
+++ b/src/test/resources/sample/shared-directory/clients.sl.yml
@@ -1,0 +1,12 @@
+---
+version: 1
+table:
+  name: "clients"
+  pattern: "clients-.*"
+  attributes:
+    - name: "id"
+      type: "string"
+      required: true
+    - name: "name"
+      type: "string"
+      required: false

--- a/src/test/resources/sample/shared-directory/clients_bis.sl.yml
+++ b/src/test/resources/sample/shared-directory/clients_bis.sl.yml
@@ -1,0 +1,12 @@
+---
+version: 1
+table:
+  name: "clients_bis"
+  pattern: "clients-.*"
+  attributes:
+    - name: "id"
+      type: "string"
+      required: true
+    - name: "name"
+      type: "string"
+      required: false

--- a/src/test/resources/sample/shared-directory/domain1.sl.yml
+++ b/src/test/resources/sample/shared-directory/domain1.sl.yml
@@ -1,0 +1,11 @@
+---
+version: 1
+load:
+  name: "SHARED1"
+  metadata:
+    directory: "__SL_TEST_ROOT__/incoming/shared"
+    format: "DSV"
+    withHeader: true
+    separator: ";"
+    writeStrategy:
+      type: "APPEND"

--- a/src/test/resources/sample/shared-directory/domain2.sl.yml
+++ b/src/test/resources/sample/shared-directory/domain2.sl.yml
@@ -1,0 +1,11 @@
+---
+version: 1
+load:
+  name: "SHARED2"
+  metadata:
+    directory: "__SL_TEST_ROOT__/incoming/shared"
+    format: "DSV"
+    withHeader: true
+    separator: ";"
+    writeStrategy:
+      type: "APPEND"

--- a/src/test/resources/sample/shared-directory/overlap1.sl.yml
+++ b/src/test/resources/sample/shared-directory/overlap1.sl.yml
@@ -1,0 +1,11 @@
+---
+version: 1
+load:
+  name: "OVERLAP1"
+  metadata:
+    directory: "__SL_TEST_ROOT__/incoming/shared-overlap"
+    format: "DSV"
+    withHeader: true
+    separator: ";"
+    writeStrategy:
+      type: "APPEND"

--- a/src/test/resources/sample/shared-directory/overlap2.sl.yml
+++ b/src/test/resources/sample/shared-directory/overlap2.sl.yml
@@ -1,0 +1,11 @@
+---
+version: 1
+load:
+  name: "OVERLAP2"
+  metadata:
+    directory: "__SL_TEST_ROOT__/incoming/shared-overlap"
+    format: "DSV"
+    withHeader: true
+    separator: ";"
+    writeStrategy:
+      type: "APPEND"

--- a/src/test/resources/sample/shared-directory/transactions.sl.yml
+++ b/src/test/resources/sample/shared-directory/transactions.sl.yml
@@ -1,0 +1,12 @@
+---
+version: 1
+table:
+  name: "transactions"
+  pattern: "transactions-.*"
+  attributes:
+    - name: "id"
+      type: "string"
+      required: true
+    - name: "amount"
+      type: "string"
+      required: false

--- a/src/test/resources/sample/shared-directory/transactions_overlap.sl.yml
+++ b/src/test/resources/sample/shared-directory/transactions_overlap.sl.yml
@@ -1,0 +1,12 @@
+---
+version: 1
+table:
+  name: "transactions"
+  pattern: "clients-.*"
+  attributes:
+    - name: "id"
+      type: "string"
+      required: true
+    - name: "amount"
+      type: "string"
+      required: false

--- a/src/test/scala/ai/starlake/schema/handlers/SharedDomainDirectorySpec.scala
+++ b/src/test/scala/ai/starlake/schema/handlers/SharedDomainDirectorySpec.scala
@@ -1,0 +1,144 @@
+package ai.starlake.schema.handlers
+
+import ai.starlake.TestHelper
+import ai.starlake.config.DatasetArea
+import ai.starlake.schema.model.Severity
+
+class SharedDomainDirectorySpec extends TestHelper {
+
+  "Domains sharing a landing directory with disjoint table patterns" should "load without error and init all dataset areas" in {
+    new WithSettings() {
+      new SpecTrait(
+        sourceDomainOrJobPathname = "/sample/shared-directory/domain1.sl.yml",
+        datasetDomainName = "SHARED1",
+        sourceDatasetPathName = ""
+      ) {
+        cleanMetadata
+        deliverSourceDomain("SHARED1", "/sample/shared-directory/domain1.sl.yml")
+        deliverSourceTable("SHARED1", "/sample/shared-directory/clients.sl.yml")
+        deliverSourceDomain("SHARED2", "/sample/shared-directory/domain2.sl.yml")
+        deliverSourceTable("SHARED2", "/sample/shared-directory/transactions.sl.yml")
+
+        val schemaHandler = settings.schemaHandler(reload = true)
+        val domains = schemaHandler.domains(reload = true)
+
+        domains.map(_.name).sorted shouldBe List("SHARED1", "SHARED2")
+        schemaHandler._domainErrors shouldBe Nil
+        // the two domains point at the same landing directory
+        domains.flatMap(_.resolveDirectoryOpt()).distinct.size shouldBe 1
+        // domains are cached and dataset areas are initialized for every domain
+        schemaHandler._domains.map(_.map(_.name).sorted) shouldBe Some(List("SHARED1", "SHARED2"))
+        List("SHARED1", "SHARED2").foreach { domain =>
+          storageHandler.exists(DatasetArea.stage(domain)) shouldBe true
+          storageHandler.exists(DatasetArea.unresolved(domain)) shouldBe true
+          storageHandler.exists(DatasetArea.archive(domain)) shouldBe true
+          storageHandler.exists(DatasetArea.replay(domain)) shouldBe true
+        }
+      }
+    }
+  }
+
+  "Domains sharing a landing directory with overlapping table patterns" should "be rejected with an error" in {
+    new WithSettings() {
+      new SpecTrait(
+        sourceDomainOrJobPathname = "/sample/shared-directory/overlap1.sl.yml",
+        datasetDomainName = "OVERLAP1",
+        sourceDatasetPathName = ""
+      ) {
+        cleanMetadata
+        deliverSourceDomain("OVERLAP1", "/sample/shared-directory/overlap1.sl.yml")
+        deliverSourceTable("OVERLAP1", "/sample/shared-directory/clients.sl.yml")
+        deliverSourceDomain("OVERLAP2", "/sample/shared-directory/overlap2.sl.yml")
+        deliverSourceTable("OVERLAP2", "/sample/shared-directory/transactions_overlap.sl.yml")
+
+        val schemaHandler = settings.schemaHandler(reload = true)
+        schemaHandler.domains(reload = true)
+
+        val errors = schemaHandler._domainErrors.filter(_.target == "Domain directory")
+        errors.size shouldBe 1
+        errors.head.severity shouldBe Severity.Error
+        errors.head.message should include("OVERLAP1")
+        errors.head.message should include("OVERLAP2")
+        errors.head.message should include("clients-.*")
+        // domains are not cached and dataset areas are not initialized
+        schemaHandler._domains shouldBe None
+        List("OVERLAP1", "OVERLAP2").foreach { domain =>
+          storageHandler.exists(DatasetArea.stage(domain)) shouldBe false
+        }
+      }
+    }
+  }
+
+  "A table pattern declared twice within one domain sharing a directory" should "be rejected with an error" in {
+    new WithSettings() {
+      new SpecTrait(
+        sourceDomainOrJobPathname = "/sample/shared-directory/overlap1.sl.yml",
+        datasetDomainName = "OVERLAP1",
+        sourceDatasetPathName = ""
+      ) {
+        cleanMetadata
+        deliverSourceDomain("OVERLAP1", "/sample/shared-directory/overlap1.sl.yml")
+        deliverSourceTable("OVERLAP1", "/sample/shared-directory/clients.sl.yml")
+        deliverSourceTable("OVERLAP1", "/sample/shared-directory/clients_bis.sl.yml")
+        deliverSourceDomain("OVERLAP2", "/sample/shared-directory/overlap2.sl.yml")
+        deliverSourceTable("OVERLAP2", "/sample/shared-directory/transactions.sl.yml")
+
+        val schemaHandler = settings.schemaHandler(reload = true)
+        schemaHandler.domains(reload = true)
+
+        val errors = schemaHandler._domainErrors.filter(_.target == "Domain directory")
+        errors.size shouldBe 1
+        errors.head.severity shouldBe Severity.Error
+        errors.head.message should include("clients-.*")
+        errors.head.message should include("2 tables")
+        schemaHandler._domains shouldBe None
+      }
+    }
+  }
+
+  "Duplicated domain names sharing a directory" should "not cache domains nor init dataset areas" in {
+    new WithSettings() {
+      new SpecTrait(
+        sourceDomainOrJobPathname = "/sample/shared-directory/domain1.sl.yml",
+        datasetDomainName = "SHARED1",
+        sourceDatasetPathName = ""
+      ) {
+        cleanMetadata
+        // same domain config (name SHARED1) delivered under two folders, disjoint table patterns
+        deliverSourceDomain("SHARED1", "/sample/shared-directory/domain1.sl.yml")
+        deliverSourceTable("SHARED1", "/sample/shared-directory/clients.sl.yml")
+        deliverSourceDomain("SHARED1BIS", "/sample/shared-directory/domain1.sl.yml")
+        deliverSourceTable("SHARED1BIS", "/sample/shared-directory/transactions.sl.yml")
+
+        val schemaHandler = settings.schemaHandler(reload = true)
+        schemaHandler.domains(reload = true)
+
+        schemaHandler._domainErrors.filter(_.target == "Domain name").size shouldBe 1
+        schemaHandler._domainErrors.filter(_.target == "Domain directory") shouldBe Nil
+        // name duplication keeps the fail-fast behavior: nothing cached, no area initialized
+        schemaHandler._domains shouldBe None
+      }
+    }
+  }
+
+  "A single domain per directory" should "keep loading without error" in {
+    new WithSettings() {
+      new SpecTrait(
+        sourceDomainOrJobPathname = "/sample/shared-directory/domain1.sl.yml",
+        datasetDomainName = "SHARED1",
+        sourceDatasetPathName = ""
+      ) {
+        cleanMetadata
+        deliverSourceDomain("SHARED1", "/sample/shared-directory/domain1.sl.yml")
+        deliverSourceTable("SHARED1", "/sample/shared-directory/clients.sl.yml")
+
+        val schemaHandler = settings.schemaHandler(reload = true)
+        val domains = schemaHandler.domains(reload = true)
+
+        domains.map(_.name) shouldBe List("SHARED1")
+        schemaHandler._domainErrors shouldBe Nil
+        storageHandler.exists(DatasetArea.stage("SHARED1")) shouldBe true
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1665

## Problem

`SchemaHandler.initDomains` rejected any two domains sharing the same `metadata.directory`, which makes a shared landing zone (managed file-receiver pattern) impossible to model. Worse, on duplicates `_domains` was not cached and `DatasetArea.initDomains` never ran, so the pending/ingesting/archive areas were left uninitialized on a fresh environment even though the rest of the pipeline handles a shared directory correctly.

## Change

- Replace the flat directory-duplicates check with `checkDomainDirectories`:
  - Domains may share a landing directory as long as no table filename pattern is declared verbatim by more than one table across the sharing domains (this also catches the same pattern declared twice inside one sharing domain).
  - Accepted sharing logs a WARNING reminding the user that only identical pattern texts are detected, and that patterns must be kept effectively disjoint for routing to stay deterministic.
  - A duplicated pattern in a shared directory raises an ERROR listing the directory, the sharing domains, the pattern and its declaring domains.
- In all accepted cases, `_domains` is cached and `DatasetArea.initDomains` runs for every domain.
- Caching/area-init is now also gated on domain-name uniqueness (`nameErrors`), preserving fail-fast when the same domain name is defined twice.

## Tests

New `SharedDomainDirectorySpec` (5 scenarios, all green locally):
- shared directory + disjoint patterns → no error, domains cached, stage/unresolved/archive/replay areas created for every domain;
- shared directory + same pattern in two domains → single "Domain directory" ERROR, nothing cached, no area created;
- same pattern declared by two tables of one sharing domain → ERROR;
- duplicated domain names sharing a directory (disjoint patterns) → name ERROR only, nothing cached;
- single domain per directory → behavior unchanged.

`SchemaInfo1HandlerSpec` and `SchemaInfo2HandlerSpec` also pass locally.

## Known limitations / follow-ups (surfaced by adversarial review)

- Overlap detection is textual (pattern-string equality). Regexes that differ as strings but match the same filenames (e.g. `clients-.*` vs `.*`) are accepted; the WARN log makes this explicit and effective disjointness remains the user's responsibility. True regex-intersection checking would need an automaton library.
- `listStageFiles` extracts and deletes `.zip/.gz/.tgz` archives found in the landing directory without pattern scoping; with a shared directory, one domain's stage run may consume a sibling domain's archives. Pre-existing behavior, newly reachable — worth a dedicated follow-up issue before recommending archives in shared landing zones.
- Directory identity is compared as a raw string (no normalization of trailing slash/`./`/case) — pre-existing, unchanged from the old check.
- No end-to-end routing test of the file-receiver scenario yet (preload/stage/load behavior over a shared directory was verified empirically in #1665).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
