### PR TITLE
fix(config): expose ConnectionInfo._transpileDialect in the application JSON schema

### DIFF
--- a/src/main/resources/starlake.json
+++ b/src/main/resources/starlake.json
@@ -314,6 +314,19 @@
         "options": {
           "$ref": "#/definitions/MapString",
           "description": "Connection options"
+        },
+        "_transpileDialect": {
+          "type": ["string", "null"],
+          "enum": [
+            null,
+            "ANY",
+            "AMAZON_REDSHIFT",
+            "DATABRICKS",
+            "DUCK_DB",
+            "GOOGLE_BIG_QUERY",
+            "SNOWFLAKE"
+          ],
+          "description": "Source SQL dialect of the transform statements executed over this connection. When set, SELECT statements are transpiled from this dialect to the connection engine dialect at run time (e.g. run BigQuery-dialect SQL locally on DuckDB). ANY stands for generic SQL"
         }
       },
       "required": ["type"]

--- a/src/main/resources/starlake_AppConfigV1.json
+++ b/src/main/resources/starlake_AppConfigV1.json
@@ -464,6 +464,19 @@
         "options": {
           "$ref": "#/definitions/MapString",
           "description": "Connection options"
+        },
+        "_transpileDialect": {
+          "type": ["string", "null"],
+          "enum": [
+            null,
+            "ANY",
+            "AMAZON_REDSHIFT",
+            "DATABRICKS",
+            "DUCK_DB",
+            "GOOGLE_BIG_QUERY",
+            "SNOWFLAKE"
+          ],
+          "description": "Source SQL dialect of the transform statements executed over this connection. When set, SELECT statements are transpiled from this dialect to the connection engine dialect at run time (e.g. run BigQuery-dialect SQL locally on DuckDB). ANY stands for generic SQL"
         }
       },
       "required": [

--- a/src/main/scala/ai/starlake/sql/SQLUtils.scala
+++ b/src/main/scala/ai/starlake/sql/SQLUtils.scala
@@ -242,7 +242,12 @@ object SQLUtils extends LazyLogging {
 
   def transpilerDialect(conn: ConnectionInfo): JSQLTranspiler.Dialect =
     conn._transpileDialect match {
-      case Some(dialect) => JSQLTranspiler.Dialect.valueOf(dialect)
+      case Some(dialect) =>
+        Try(JSQLTranspiler.Dialect.valueOf(dialect)).getOrElse(
+          throw new IllegalArgumentException(
+            s"Invalid _transpileDialect '$dialect'. Valid values are ${JSQLTranspiler.Dialect.values().map(_.name()).mkString(", ")}"
+          )
+        )
       case None =>
         if (conn.isSpark())
           JSQLTranspiler.Dialect.DATABRICKS

--- a/src/test/scala/ai/starlake/config/TranspileDialectAppConfigSpec.scala
+++ b/src/test/scala/ai/starlake/config/TranspileDialectAppConfigSpec.scala
@@ -1,0 +1,134 @@
+package ai.starlake.config
+
+import ai.starlake.TestHelper
+import ai.starlake.exceptions.SchemaValidationException
+import ai.starlake.schema.model.ConnectionType
+import ai.starlake.sql.SQLUtils
+import ai.starlake.transpiler.JSQLTranspiler
+import ai.starlake.utils.YamlSerde
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.hadoop.fs.Path
+
+import scala.jdk.CollectionConverters._
+
+class TranspileDialectAppConfigSpec extends TestHelper {
+
+  private def applicationConfig(dialect: String): String =
+    s"""
+       |version: 1
+       |application:
+       |  connections:
+       |    duckdb:
+       |      type: "jdbc"
+       |      _transpileDialect: "$dialect"
+       |      options:
+       |        url: "jdbc:duckdb:/tmp/duckdb.db"
+       |""".stripMargin
+
+  "An application config with a connection _transpileDialect" should "pass schema validation" in {
+    val node = YamlSerde.deserializeYamlApplicationNode(
+      applicationConfig("GOOGLE_BIG_QUERY"),
+      "application.sl.yml"
+    )
+    node
+      .path("application")
+      .path("connections")
+      .path("duckdb")
+      .path("_transpileDialect")
+      .asText() shouldBe "GOOGLE_BIG_QUERY"
+  }
+
+  it should "reach ConnectionInfo._transpileDialect once the application is loaded" in {
+    new WithSettings() {
+      val appConfig = Settings.loadApplication(
+        applicationConfig("GOOGLE_BIG_QUERY"),
+        new Path("application.sl.yml"),
+        starlakeTestRoot
+      )
+      appConfig.connections("duckdb")._transpileDialect shouldBe Some("GOOGLE_BIG_QUERY")
+    }
+  }
+
+  "every JSQLTranspiler dialect" should "be accepted by the application schema" in {
+    JSQLTranspiler.Dialect.values().foreach { dialect =>
+      withClue(s"dialect ${dialect.name()}:") {
+        noException should be thrownBy
+        YamlSerde.deserializeYamlApplicationNode(
+          applicationConfig(dialect.name()),
+          "application.sl.yml"
+        )
+      }
+    }
+  }
+
+  "a null _transpileDialect" should "be accepted like any other unset connection property" in {
+    new WithSettings() {
+      val config =
+        """
+          |version: 1
+          |application:
+          |  connections:
+          |    duckdb:
+          |      type: "jdbc"
+          |      _transpileDialect:
+          |      options:
+          |        url: "jdbc:duckdb:/tmp/duckdb.db"
+          |""".stripMargin
+      val appConfig =
+        Settings.loadApplication(config, new Path("application.sl.yml"), starlakeTestRoot)
+      appConfig.connections("duckdb")._transpileDialect shouldBe None
+    }
+  }
+
+  "an invalid _transpileDialect value" should "be rejected by schema validation" in {
+    val ex = intercept[SchemaValidationException] {
+      YamlSerde.deserializeYamlApplicationNode(
+        applicationConfig("NOT_A_DIALECT"),
+        "application.sl.yml"
+      )
+    }
+    ex.getMessage should include("_transpileDialect")
+  }
+
+  "the _transpileDialect enum in the schema resources" should "match the JSQLTranspiler dialects" in {
+    val dialects = JSQLTranspiler.Dialect.values().map(_.name()).toList.sorted
+    val mapper = new ObjectMapper()
+    List("/starlake.json", "/starlake_AppConfigV1.json").foreach { resource =>
+      val stream = getClass.getResourceAsStream(resource)
+      withClue(s"schema resource $resource:") {
+        stream should not be null
+      }
+      val schema = mapper.readTree(stream)
+      val schemaDialects = schema
+        .path("definitions")
+        .path("ConnectionV1")
+        .path("properties")
+        .path("_transpileDialect")
+        .path("enum")
+        .elements()
+        .asScala
+        .filterNot(_.isNull)
+        .map(_.asText())
+        .toList
+      withClue(s"$resource ConnectionV1._transpileDialect enum:") {
+        schemaDialects.sorted shouldBe dialects
+        schemaDialects.distinct.size shouldBe schemaDialects.size
+      }
+    }
+  }
+
+  "SQLUtils.transpilerDialect" should "resolve a declared dialect and reject an invalid one with a meaningful error" in {
+    def connection(dialect: String): ConnectionInfo =
+      ConnectionInfo(
+        `type` = ConnectionType.JDBC,
+        options = Map("url" -> "jdbc:duckdb:/tmp/duckdb.db"),
+        _transpileDialect = Some(dialect)
+      )
+    SQLUtils.transpilerDialect(connection("SNOWFLAKE")) shouldBe JSQLTranspiler.Dialect.SNOWFLAKE
+    val ex = intercept[IllegalArgumentException] {
+      SQLUtils.transpilerDialect(connection("NOT_A_DIALECT"))
+    }
+    ex.getMessage should include("NOT_A_DIALECT")
+    ex.getMessage should include("GOOGLE_BIG_QUERY")
+  }
+}

--- a/src/test/scala/ai/starlake/schema/generator/YamlSerdeSpec.scala
+++ b/src/test/scala/ai/starlake/schema/generator/YamlSerdeSpec.scala
@@ -1144,12 +1144,18 @@ object YamlConfigGenerators {
           m + ("url" -> "jdbc:mysql://myhost")
         else m
       )
+      transpileDialect <- Gen.option(
+        Gen.oneOf(
+          ai.starlake.transpiler.JSQLTranspiler.Dialect.values().toIndexedSeq.map(_.name())
+        )
+      )
     } yield ConnectionInfo(
       `type` = ConnectionType.fromString(connectionType),
       sparkFormat = sparkFormat,
       quote = quote,
       separator = separator,
-      options = options
+      options = options,
+      _transpileDialect = transpileDialect
     )
   }
 


### PR DESCRIPTION
Fixes #1666

## Problem

`ConnectionInfo._transpileDialect` exists in the model and is honored by the engine (`SqlTransformations.transpileAndSubstituteSelectStatement`, `SQLUtils.transpilerDialect`), but it could not be set from `application.sl.yml`: the application JSON schema only allowed `type/sparkFormat/loader/quote/separator/options` on a connection, and strict validation (`unevaluatedProperties: false`) rejected the file before the engine ever saw the field. RUN-mode transpilation (e.g. running BigQuery-dialect transform SQL locally on DuckDB) was effectively unreachable from a YAML project.

## Change

- Add `_transpileDialect` to the `ConnectionV1` definition in both schema resources:
  - `starlake.json` — the aggregate schema actually loaded by `YamlSerde.validateConfigFile` at runtime;
  - `starlake_AppConfigV1.json` — the per-config fragment shipped to projects (IDE completion).
  The property is `["string", "null"]` with an enum of the `JSQLTranspiler.Dialect` values (`ANY`, `AMAZON_REDSHIFT`, `DATABRICKS`, `DUCK_DB`, `GOOGLE_BIG_QUERY`, `SNOWFLAKE`) plus `null`, so an empty placeholder value behaves like every sibling `ConvertibleToString` property. The enum gives IDE completion and catches typos at validation time. Jinja/env substitution runs before validation on the runtime path, so templated values keep working.
- `SQLUtils.transpilerDialect` now rejects an invalid declared dialect with an `IllegalArgumentException` listing the valid values, instead of a bare `Dialect.valueOf` stack trace — this covers config paths that bypass the JSON schema (typesafe `application.conf`, programmatic construction).

## Tests

New `TranspileDialectAppConfigSpec` (7 tests, green locally):
- a connection with `_transpileDialect` passes schema validation and the value survives in the node;
- end-to-end `Settings.loadApplication` → `AppConfig.connections(...)._transpileDialect` is populated (guards the pureconfig CamelCase mapping of the leading-underscore field);
- every `JSQLTranspiler.Dialect` value is accepted;
- an explicit null `_transpileDialect` is accepted and maps to `None`;
- an invalid value is rejected with a `SchemaValidationException` mentioning `_transpileDialect`;
- a sync test pins the enum in **both** JSON resources to `JSQLTranspiler.Dialect.values()` (duplicate-safe, sorted-list compare), so a transpiler upgrade adding a dialect fails the build until the schemas are updated;
- `SQLUtils.transpilerDialect` resolves a declared dialect and reports invalid ones with a meaningful error.

The `Arbitrary[ConnectionInfo]` generator in `YamlSerdeSpec` now also generates `_transpileDialect`, so the application round-trip property test exercises serialization/validation of the field.

## Notes (adversarial review outcomes)

- `Settings.loadApplication` validates content without a Jinja pass (unlike the runtime `loadApplicationYaml` path, which substitutes first). It has no caller in core main sources; external callers passing a Jinja-templated `_transpileDialect` through it would be rejected by the enum. Documented here as a known limitation of that entry point.
- The user-facing documentation for connections lives in the docs site repo; `_transpileDialect` should be documented there as the supported way to run dialect-X SQL on a local engine — docs follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
