### PR TITLE
Add semantic-export command: export semantic models to Apache Ossie

### DIFF
--- a/src/main/scala/ai/starlake/job/Main.scala
+++ b/src/main/scala/ai/starlake/job/Main.scala
@@ -30,6 +30,7 @@ import ai.starlake.migration.MigrateCmd
 import ai.starlake.schema.ProjectCompareCmd
 import ai.starlake.schema.generator.*
 import ai.starlake.schema.handlers.{SchemaHandler, ValidateCmd}
+import ai.starlake.semantic.SemanticExportCmd
 import ai.starlake.serve.MainServerCmd
 import ai.starlake.sql.StarlakeJdbcDialects
 import ai.starlake.tests.StarlakeTestCmd
@@ -129,7 +130,8 @@ object Main extends LazyLogging {
     SummarizeCmd,
     JobCmd,
     GizmoCmd,
-    QuackCmd
+    QuackCmd,
+    SemanticExportCmd
   )
 }
 

--- a/src/main/scala/ai/starlake/semantic/SemanticExportCmd.scala
+++ b/src/main/scala/ai/starlake/semantic/SemanticExportCmd.scala
@@ -1,0 +1,85 @@
+package ai.starlake.semantic
+
+import ai.starlake.config.Settings
+import ai.starlake.job.Cmd
+import ai.starlake.schema.handlers.SchemaHandler
+import ai.starlake.utils.JobResult
+import scopt.OParser
+
+import scala.util.Try
+
+/** Command to export semantic models to an interchange format.
+  *
+  * Usage: starlake semantic-export [options]
+  */
+object SemanticExportCmd extends Cmd[SemanticExportConfig] {
+
+  val command = "semantic-export"
+
+  override def pageDescription: String =
+    "Export semantic models from metadata/semantic to a vendor-neutral interchange format (Apache Ossie)."
+  override def pageKeywords: Seq[String] =
+    Seq(
+      "starlake semantic-export",
+      "semantic model",
+      "semantic layer",
+      "apache ossie",
+      "open semantic interchange",
+      "BI",
+      "AI agents"
+    )
+
+  val parser: OParser[Unit, SemanticExportConfig] = {
+    val builder = OParser.builder[SemanticExportConfig]
+    OParser.sequence(
+      builder.programName(s"$shell $command"),
+      builder.head(shell, command, "[options]"),
+      builder.note(
+        """
+          |Export the semantic models stored in metadata/semantic/ to a vendor-neutral
+          |interchange format. Currently supported format: ossie (Apache Ossie, incubating,
+          |formerly Open Semantic Interchange).
+          |
+          |Fields, primary keys, relationships, and metrics are mapped to their Ossie
+          |equivalents; Starlake-specific attributes with no Ossie counterpart (filters,
+          |sample values, verified query SQL, join types...) are preserved in
+          |custom_extensions blocks under the STARLAKE vendor name so no information is lost.
+          |
+          |example: starlake semantic-export
+          |         --format ossie
+          |         --model ecommerce_analytics
+          |         --output /tmp/ossie-models""".stripMargin
+      ),
+      builder
+        .opt[String]("format")
+        .action((x, c) => c.copy(format = x))
+        .validate(x =>
+          if (x == "ossie") builder.success
+          else builder.failure(s"Unsupported format '$x'. Supported formats: ossie")
+        )
+        .text("Target interchange format. Only 'ossie' is supported for now (default)")
+        .optional(),
+      builder
+        .opt[String]("model")
+        .action((x, c) => c.copy(model = Some(x)))
+        .text(
+          "Name of a single semantic model to export (model 'name' field or file basename). All models by default"
+        )
+        .optional(),
+      builder
+        .opt[String]("output")
+        .action((x, c) => c.copy(output = Some(x)))
+        .text("Output directory. Defaults to metadata/semantic/export/ with one subfolder per format")
+        .optional(),
+      reportFormatOption(builder)((c, x) => c.copy(reportFormat = x))
+    )
+  }
+
+  def parse(args: Seq[String]): Option[SemanticExportConfig] =
+    OParser.parse(parser, args, SemanticExportConfig(), setup)
+
+  override def run(config: SemanticExportConfig, schemaHandler: SchemaHandler)(implicit
+    settings: Settings
+  ): Try[JobResult] =
+    new SemanticExportJob(config).run()
+}

--- a/src/main/scala/ai/starlake/semantic/SemanticExportConfig.scala
+++ b/src/main/scala/ai/starlake/semantic/SemanticExportConfig.scala
@@ -1,0 +1,10 @@
+package ai.starlake.semantic
+
+import ai.starlake.job.ReportFormatConfig
+
+case class SemanticExportConfig(
+  format: String = "ossie",
+  model: Option[String] = None,
+  output: Option[String] = None,
+  reportFormat: Option[String] = None
+) extends ReportFormatConfig

--- a/src/main/scala/ai/starlake/semantic/SemanticExportJob.scala
+++ b/src/main/scala/ai/starlake/semantic/SemanticExportJob.scala
@@ -1,0 +1,274 @@
+package ai.starlake.semantic
+
+import ai.starlake.config.{DatasetArea, Settings}
+import ai.starlake.utils.{JobResult, Utils, YamlSerde}
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.{ArrayNode, ObjectNode}
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.hadoop.fs.Path
+
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+/** Exports semantic models stored in metadata/semantic/ to the Apache Ossie (incubating)
+  * interchange format.
+  *
+  * Input models follow the Snowflake-style semantic model layout (tables with dimensions /
+  * time_dimensions / facts / metrics / filters, relationships, model-level metrics,
+  * verified_queries). Attributes with no Ossie equivalent are preserved verbatim in
+  * `custom_extensions` blocks under the STARLAKE vendor name.
+  */
+class SemanticExportJob(config: SemanticExportConfig)(implicit settings: Settings)
+    extends LazyLogging {
+
+  private val storage = settings.storageHandler()
+
+  def run(): Try[JobResult] = Try {
+    val semanticPath = DatasetArea.semantic
+    val modelFiles =
+      (storage.list(semanticPath, ".yaml", recursive = false) ++
+        storage.list(semanticPath, ".yml", recursive = false)).map(_.path).distinct
+
+    val models = modelFiles.map { path =>
+      val node = YamlSerde.mapper.readTree(storage.read(path))
+      val basename = path.getName.replaceAll("\\.ya?ml$", "")
+      val name = Option(node.path("name").asText(null)).filter(_.nonEmpty).getOrElse(basename)
+      (path, basename, name, node)
+    }
+
+    val selected = config.model match {
+      case Some(m) =>
+        val hits = models.filter { case (_, basename, name, _) => m == name || m == basename }
+        if (hits.isEmpty)
+          throw new IllegalArgumentException(
+            s"Semantic model '$m' not found in $semanticPath. " +
+            s"Available models: ${models.map(_._3).mkString(", ")}"
+          )
+        hits
+      case None => models
+    }
+
+    if (selected.isEmpty)
+      logger.warn(s"No semantic model found in $semanticPath, nothing to export")
+
+    val outputDir = config.output
+      .map(new Path(_))
+      .getOrElse(new Path(semanticPath, s"export/${config.format}"))
+    storage.mkdirs(outputDir)
+
+    selected.foreach { case (path, _, name, node) =>
+      val ossie = OssieConverter.convert(name, node)
+      val target = new Path(outputDir, s"$name.ossie.yaml")
+      storage.write(YamlSerde.mapper.writeValueAsString(ossie), target)
+      logger.info(s"Exported semantic model '$name' ($path) to $target")
+    }
+    JobResult.empty
+  }
+}
+
+/** Pure JsonNode-to-JsonNode conversion from the Snowflake-style semantic model format to
+  * Apache Ossie (spec version 0.2.0.dev0).
+  */
+object OssieConverter {
+
+  /** Ossie core-spec version this converter targets. */
+  val SpecVersion = "0.2.0.dev0"
+  private val Vendor = "STARLAKE"
+
+  private def yamlMapper = YamlSerde.mapper
+  private val jsonMapper = Utils.newJsonMapper()
+
+  def convert(modelName: String, model: JsonNode): ObjectNode = {
+    val root = yamlMapper.createObjectNode()
+    root.put("version", SpecVersion)
+    val sm = yamlMapper.createObjectNode()
+    root.set[ObjectNode]("semantic_model", yamlMapper.createArrayNode().add(sm))
+
+    sm.put("name", modelName)
+    copyText(model, "description", sm)
+
+    // Model-level ai_context: verified query questions become AI examples.
+    val questions = elems(model, "verified_queries").flatMap(q => text(q, "question"))
+    if (questions.nonEmpty) {
+      val ai = sm.putObject("ai_context")
+      val ex = ai.putArray("examples")
+      questions.foreach(ex.add)
+    }
+
+    val datasets = sm.putArray("datasets")
+    elems(model, "tables").foreach(table => datasets.add(dataset(table)))
+
+    val relationships = elems(model, "relationships").map(relationship)
+    if (relationships.nonEmpty) {
+      val arr = sm.putArray("relationships")
+      relationships.foreach(arr.add)
+    }
+
+    val tableMetrics = elems(model, "tables").flatMap { table =>
+      elems(table, "metrics").map(m => metric(m, sourceDataset = text(table, "name")))
+    }
+    val modelMetrics = elems(model, "metrics").map(m => metric(m, sourceDataset = None))
+    if ((tableMetrics ++ modelMetrics).nonEmpty) {
+      val arr = sm.putArray("metrics")
+      (tableMetrics ++ modelMetrics).foreach(arr.add)
+    }
+
+    // Preserve verified queries (with SQL) losslessly.
+    if (model.has("verified_queries"))
+      starlakeExtension(sm, "verified_queries", model.get("verified_queries"))
+
+    root
+  }
+
+  private def dataset(table: JsonNode): ObjectNode = {
+    val ds = yamlMapper.createObjectNode()
+    ds.put("name", table.path("name").asText())
+    ds.put("source", source(table))
+    copyText(table, "description", ds)
+
+    val pkColumns = elems(table.path("primary_key"), "columns").map(_.asText())
+    if (pkColumns.nonEmpty) {
+      val pk = ds.putArray("primary_key")
+      pkColumns.foreach(pk.add)
+    }
+
+    val uniqueDims =
+      elems(table, "dimensions").filter(_.path("unique").asBoolean(false)).flatMap(text(_, "name"))
+    if (uniqueDims.nonEmpty) {
+      val uk = ds.putArray("unique_keys")
+      uniqueDims.foreach(c => uk.add(yamlMapper.createArrayNode().add(c)))
+    }
+
+    val fields = ds.putArray("fields")
+    elems(table, "dimensions").foreach(d => fields.add(field(d, isTime = Some(false))))
+    elems(table, "time_dimensions").foreach(d => fields.add(field(d, isTime = Some(true))))
+    elems(table, "facts").foreach(f => fields.add(field(f, isTime = None)))
+
+    if (table.has("filters"))
+      starlakeExtension(ds, "filters", table.get("filters"))
+    ds
+  }
+
+  private def field(col: JsonNode, isTime: Option[Boolean]): ObjectNode = {
+    val f = yamlMapper.createObjectNode()
+    val name = col.path("name").asText()
+    f.put("name", name)
+    expression(f, text(col, "expr").getOrElse(name))
+    copyText(col, "description", f)
+    text(col, "data_type").flatMap(datatype).foreach(f.put("datatype", _))
+    isTime.foreach(t => f.putObject("dimension").put("is_time", t))
+    synonyms(col, f)
+
+    val kept = List("unique", "is_enum", "sample_values", "access_modifier", "cortex_search_service")
+      .filter(col.has)
+    if (kept.nonEmpty) {
+      val extra = jsonMapper.createObjectNode()
+      kept.foreach(k => extra.set[JsonNode](k, col.get(k)))
+      starlakeExtensionNode(f, extra)
+    }
+    f
+  }
+
+  private def relationship(rel: JsonNode): ObjectNode = {
+    val r = yamlMapper.createObjectNode()
+    r.put("name", rel.path("name").asText())
+    r.put("from", rel.path("left_table").asText())
+    r.put("to", rel.path("right_table").asText())
+    val from = r.putArray("from_columns")
+    val to = r.putArray("to_columns")
+    elems(rel, "relationship_columns").foreach { rc =>
+      text(rc, "left_column").foreach(from.add)
+      text(rc, "right_column").foreach(to.add)
+    }
+    val kept = List("join_type", "relationship_type").filter(rel.has)
+    if (kept.nonEmpty) {
+      val extra = jsonMapper.createObjectNode()
+      kept.foreach(k => extra.set[JsonNode](k, rel.get(k)))
+      starlakeExtensionNode(r, extra)
+    }
+    r
+  }
+
+  private def metric(m: JsonNode, sourceDataset: Option[String]): ObjectNode = {
+    val out = yamlMapper.createObjectNode()
+    out.put("name", m.path("name").asText())
+    expression(out, m.path("expr").asText())
+    copyText(m, "description", out)
+    synonyms(m, out)
+    sourceDataset.foreach { ds =>
+      val extra = jsonMapper.createObjectNode()
+      extra.put("source_dataset", ds)
+      starlakeExtensionNode(out, extra)
+    }
+    out
+  }
+
+  // ── helpers ──────────────────────────────────────────────────────────
+
+  private def source(table: JsonNode): String = {
+    val base = table.path("base_table")
+    val parts =
+      List("database", "schema", "table").flatMap(k => text(base, k)).filter(_.nonEmpty)
+    if (parts.nonEmpty) parts.mkString(".") else table.path("name").asText()
+  }
+
+  private def expression(target: ObjectNode, expr: String): Unit = {
+    val dialect = target.putObject("expression").putArray("dialects").addObject()
+    dialect.put("dialect", "ANSI_SQL")
+    dialect.put("expression", expr)
+  }
+
+  private def synonyms(from: JsonNode, target: ObjectNode): Unit = {
+    val syns = elems(from, "synonyms").map(_.asText()).filter(_.nonEmpty)
+    if (syns.nonEmpty) {
+      val arr = target.putObject("ai_context").putArray("synonyms")
+      syns.foreach(arr.add)
+    }
+  }
+
+  /** Map Snowflake-style datatypes to the Ossie datatype enum. Unknown types map to Opaque;
+    * absent types are omitted.
+    */
+  private def datatype(raw: String): Option[String] = {
+    val t = raw.trim.toUpperCase
+    if (t.isEmpty) None
+    else
+      Some(t match {
+        case "TEXT" | "STRING" | "VARCHAR" | "CHAR"          => "String"
+        case "INT" | "INTEGER" | "BIGINT" | "SMALLINT"       => "Integer"
+        case "NUMBER" | "NUMERIC" | "DECIMAL"                => "Decimal"
+        case "FLOAT" | "DOUBLE" | "REAL"                     => "Float"
+        case "BOOLEAN" | "BOOL"                              => "Boolean"
+        case "DATE"                                          => "Date"
+        case "TIME"                                          => "Time"
+        case "DATETIME" | "TIMESTAMP" | "TIMESTAMP_NTZ" | "TIMESTAMP_LTZ" => "DateTime"
+        case "TIMESTAMP_TZ"                                  => "DateTimeTz"
+        case _                                               => "Opaque"
+      })
+  }
+
+  private def starlakeExtension(target: ObjectNode, key: String, value: JsonNode): Unit = {
+    val extra = jsonMapper.createObjectNode()
+    extra.set[JsonNode](key, value)
+    starlakeExtensionNode(target, extra)
+  }
+
+  private def starlakeExtensionNode(target: ObjectNode, data: ObjectNode): Unit = {
+    val extensions =
+      if (target.has("custom_extensions")) target.get("custom_extensions").asInstanceOf[ArrayNode]
+      else target.putArray("custom_extensions")
+    val ext = extensions.addObject()
+    ext.put("vendor_name", Vendor)
+    ext.put("data", jsonMapper.writeValueAsString(data))
+  }
+
+  private def elems(node: JsonNode, key: String): List[JsonNode] =
+    if (node.has(key) && node.get(key).isArray) node.get(key).elements().asScala.toList
+    else Nil
+
+  private def text(node: JsonNode, key: String): Option[String] =
+    Option(node.path(key).asText(null)).filter(_.nonEmpty)
+
+  private def copyText(from: JsonNode, key: String, target: ObjectNode): Unit =
+    text(from, key).foreach(target.put(key, _))
+}

--- a/src/test/scala/ai/starlake/semantic/SemanticExportSpec.scala
+++ b/src/test/scala/ai/starlake/semantic/SemanticExportSpec.scala
@@ -1,0 +1,168 @@
+package ai.starlake.semantic
+
+import ai.starlake.TestHelper
+import ai.starlake.config.DatasetArea
+import ai.starlake.utils.YamlSerde
+import org.apache.hadoop.fs.Path
+
+import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success}
+
+class SemanticExportSpec extends TestHelper {
+
+  private val modelYaml =
+    """name: ecommerce_analytics
+      |description: E-commerce analytics model
+      |tables:
+      |  - name: orders
+      |    description: Order transactions
+      |    base_table:
+      |      database: ANALYTICS_DB
+      |      schema: ECOMMERCE
+      |      table: ORDERS
+      |    dimensions:
+      |      - name: order_id
+      |        expr: ORDER_ID
+      |        data_type: NUMBER
+      |        unique: true
+      |      - name: order_status
+      |        expr: ORDER_STATUS
+      |        data_type: TEXT
+      |        is_enum: true
+      |        synonyms: ["status"]
+      |        sample_values: ["Pending", "Shipped"]
+      |    time_dimensions:
+      |      - name: order_date
+      |        expr: ORDER_DATE
+      |        data_type: DATE
+      |    facts:
+      |      - name: order_total
+      |        expr: ORDER_TOTAL
+      |        data_type: NUMBER
+      |        access_modifier: public_access
+      |    metrics:
+      |      - name: avg_order_value
+      |        expr: AVG(order_total)
+      |        synonyms: ["AOV"]
+      |    filters:
+      |      - name: recent_orders
+      |        expr: order_date >= DATEADD(day, -30, CURRENT_DATE())
+      |    primary_key:
+      |      columns: [order_id]
+      |  - name: customers
+      |    base_table:
+      |      database: ANALYTICS_DB
+      |      schema: ECOMMERCE
+      |      table: CUSTOMERS
+      |    dimensions:
+      |      - name: customer_id
+      |        expr: CUSTOMER_ID
+      |        data_type: NUMBER
+      |        unique: true
+      |    primary_key:
+      |      columns: [customer_id]
+      |relationships:
+      |  - name: orders_to_customers
+      |    left_table: orders
+      |    right_table: customers
+      |    relationship_columns:
+      |      - left_column: customer_id
+      |        right_column: customer_id
+      |    join_type: left_outer
+      |    relationship_type: many_to_one
+      |metrics:
+      |  - name: customer_count
+      |    expr: COUNT(DISTINCT customers.customer_id)
+      |verified_queries:
+      |  - name: top_customers
+      |    question: Who are the top 10 customers by revenue?
+      |    sql: SELECT 1
+      |""".stripMargin
+
+  "semantic-export" should "convert a Snowflake-style model to Ossie" in {
+    new WithSettings() {
+      cleanMetadata
+      val storage = settings.storageHandler()
+      storage.write(modelYaml, new Path(DatasetArea.semantic, "ecommerce.yaml"))
+
+      new SemanticExportJob(SemanticExportConfig()).run() match {
+        case Failure(exception) => throw exception
+        case Success(_)         =>
+      }
+
+      val exported =
+        storage.read(new Path(DatasetArea.semantic, "export/ossie/ecommerce_analytics.ossie.yaml"))
+      val root = YamlSerde.mapper.readTree(exported)
+
+      root.path("version").asText() shouldBe OssieConverter.SpecVersion
+      val sm = root.path("semantic_model").get(0)
+      sm.path("name").asText() shouldBe "ecommerce_analytics"
+
+      // datasets
+      val datasets = sm.path("datasets").elements().asScala.toList
+      datasets.map(_.path("name").asText()) shouldBe List("orders", "customers")
+      val orders = datasets.head
+      orders.path("source").asText() shouldBe "ANALYTICS_DB.ECOMMERCE.ORDERS"
+      orders.path("primary_key").get(0).asText() shouldBe "order_id"
+      orders.path("unique_keys").get(0).get(0).asText() shouldBe "order_id"
+
+      // fields: 2 dimensions + 1 time dimension + 1 fact
+      val fields = orders.path("fields").elements().asScala.toList
+      fields.map(_.path("name").asText()) shouldBe
+        List("order_id", "order_status", "order_date", "order_total")
+      val status = fields(1)
+      status.path("datatype").asText() shouldBe "String"
+      status.path("dimension").path("is_time").asBoolean() shouldBe false
+      status.path("ai_context").path("synonyms").get(0).asText() shouldBe "status"
+      status
+        .path("expression")
+        .path("dialects")
+        .get(0)
+        .path("expression")
+        .asText() shouldBe "ORDER_STATUS"
+      fields(2).path("dimension").path("is_time").asBoolean() shouldBe true
+      fields(2).path("datatype").asText() shouldBe "Date"
+      // facts carry no dimension block
+      fields(3).has("dimension") shouldBe false
+
+      // relationship
+      val rel = sm.path("relationships").get(0)
+      rel.path("from").asText() shouldBe "orders"
+      rel.path("to").asText() shouldBe "customers"
+      rel.path("from_columns").get(0).asText() shouldBe "customer_id"
+      rel.path("to_columns").get(0).asText() shouldBe "customer_id"
+
+      // metrics: table-level metric hoisted to model level + model-level metric
+      val metrics = sm.path("metrics").elements().asScala.toList
+      metrics.map(_.path("name").asText()) shouldBe List("avg_order_value", "customer_count")
+
+      // ai examples from verified queries; SQL preserved in custom_extensions
+      sm.path("ai_context")
+        .path("examples")
+        .get(0)
+        .asText() shouldBe "Who are the top 10 customers by revenue?"
+      val ext = sm.path("custom_extensions").get(0)
+      ext.path("vendor_name").asText() shouldBe "STARLAKE"
+      ext.path("data").asText() should include("top_customers")
+    }
+  }
+
+  it should "filter by model name and fail on unknown models" in {
+    new WithSettings() {
+      cleanMetadata
+      val storage = settings.storageHandler()
+      storage.write(modelYaml, new Path(DatasetArea.semantic, "ecommerce.yaml"))
+
+      new SemanticExportJob(SemanticExportConfig(model = Some("ecommerce"))).run() match {
+        case Failure(exception) => throw exception
+        case Success(_)         =>
+      }
+      storage.exists(
+        new Path(DatasetArea.semantic, "export/ossie/ecommerce_analytics.ossie.yaml")
+      ) shouldBe true
+
+      val unknown = new SemanticExportJob(SemanticExportConfig(model = Some("nope"))).run()
+      unknown.isFailure shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new CLI command `starlake semantic-export` that exports the semantic models stored in `metadata/semantic/` to the vendor-neutral [Apache Ossie (incubating)](https://github.com/apache/ossie) interchange format (formerly Open Semantic Interchange), targeting core-spec `0.2.0.dev0`.

```bash
starlake semantic-export                              # all models -> metadata/semantic/export/ossie/
starlake semantic-export --model ecommerce_analytics  # one model, by name field or file basename
starlake semantic-export --output /tmp/ossie-models   # custom output directory
```

## Mapping

| Starlake semantic model | Ossie |
|---|---|
| model name / description | `semantic_model[0]` |
| tables | `datasets` (dotted `source`, `primary_key`, `unique_keys`) |
| dimensions / time_dimensions / facts | `fields` with `expression.dialects` (ANSI_SQL), datatype enum, `dimension.is_time` |
| synonyms, verified-query questions | structured `ai_context` (`synonyms` / `examples`) |
| table + model metrics | model-level `metrics` |
| relationships | `from`/`to` with column arrays |

Lossless: attributes with no Ossie equivalent (filters, `sample_values`, `is_enum`, `access_modifier`, `cortex_search_service`, verified query SQL, join types) are preserved in `custom_extensions` under `vendor_name: STARLAKE`.

## Implementation

- New `ai.starlake.semantic` package (Config / Cmd / Job + pure `OssieConverter`), following the `parquet2csv` / `yml2ddl` command pattern; registered in `Main.commands` so console autocompletion and CLI doc generation pick it up automatically.
- JsonNode-based conversion via `YamlSerde.mapper`: resilient to unknown input fields, no new dependencies.

## Test plan

- `sbt "testOnly *SemanticExportSpec*"`: 2 specs covering the full mapping (datasets, fields, datatypes, is_time, synonyms, relationships, metric hoisting, ai_context examples, STARLAKE extensions), plus `--model` filtering and unknown-model failure. Both green.
- `sbt compile` and `CliConfigSpec` doc generation pass (generated page reviewed for MDX safety).

🤖 Generated with [Claude Code](https://claude.com/claude-code)