### PR TITLE
Windows setup: real java version check (JAVA_HOME-aware) + embedded JDK fallback in the install dir

### DIFF
--- a/distrib/setup.ps1
+++ b/distrib/setup.ps1
@@ -114,22 +114,99 @@ function print_success_message {
     Write-Host "Starlake has been successfully installed!"
 }
 
-function check_java_version {
-    # Check if Java is installed using JAVA_HOME env variable
-    if ($null -eq $env:JAVA_HOME) {
-        $runner = "java"
+function get_java_major_version {
+    # Parse the REAL runtime version from `java -version` (stderr). The file
+    # version of java.exe is unreliable, and string comparison is lexicographic
+    # ("8.0" -lt "11" is false), which used to let Java 8 pass the check.
+    # Handles both version schemes: "17.0.12" -> 17, "1.8.0_292" -> 8.
+    param([string]$JavaExe)
+    if (-not (Test-Path $JavaExe) -and -not (Get-Command $JavaExe -ErrorAction SilentlyContinue)) {
+        return 0
+    }
+    $line = & $JavaExe -version 2>&1 | Select-Object -First 1
+    if ("$line" -match 'version "(\d+)(?:\.(\d+))?') {
+        $major = [int]$Matches[1]
+        if ($major -eq 1 -and $Matches[2]) { $major = [int]$Matches[2] }
+        return $major
+    }
+    return 0
+}
+
+function resolve_java {
+    # JAVA_HOME wins when it is set (that is also what starlake.cmd executes);
+    # otherwise fall back to `java` from the PATH.
+    if ($env:JAVA_HOME) {
+        $exe = Join-Path $env:JAVA_HOME "bin\java.exe"
+        if (Test-Path $exe) {
+            return @{ Exe = $exe; Major = (get_java_major_version $exe); Source = "JAVA_HOME ($env:JAVA_HOME)" }
+        }
+    }
+    $cmd = Get-Command java -ErrorAction SilentlyContinue
+    if ($cmd) {
+        return @{ Exe = $cmd.Source; Major = (get_java_major_version $cmd.Source); Source = "PATH ($($cmd.Source))" }
+    }
+    return @{ Exe = ""; Major = 0; Source = "none" }
+}
+
+function ensure_java {
+    # Check the installed Java (JAVA_HOME first). If none is found, or its
+    # version is below the required minimum, install an EMBEDDED portable
+    # Temurin JDK inside the starlake install directory (<install-dir>\jdk)
+    # and update the SESSION environment (JAVA_HOME + PATH). No administrator
+    # rights: portable zip + process-scoped variables only. starlake.cmd picks
+    # the embedded JDK up automatically in later sessions.
+    param([string]$InstallDir, [int]$MinVersion = 11, [int]$EmbeddedVersion = 17)
+
+    $java = resolve_java
+    if ($java.Major -ge $MinVersion) {
+        Write-Host "Using Java $($java.Major) from $($java.Source)"
+        return
+    }
+    if ($java.Major -gt 0) {
+        Write-Host "Java $($java.Major) found via $($java.Source) but Java $MinVersion or above is required."
     } else {
-        $runner = "$env:JAVA_HOME\bin\java"
+        Write-Host "No Java found (checked JAVA_HOME and PATH). Java $MinVersion or above is required."
     }
-    $javaVersion = (Get-Command $runner | Select-Object -ExpandProperty Version).tostring()
-    if ($null -eq $javaVersion) {
-        Write-Host "Java is not installed. Please install Java 11 or above."
+
+    $jdkDir = Join-Path $InstallDir "jdk"
+    Write-Host "Installing an embedded Temurin $EmbeddedVersion JDK into $jdkDir (portable zip, no administrator rights)"
+    # The Adoptium API redirects to the latest GA windows x64 JDK zip. On
+    # Windows-on-ARM the x64 build runs fine under the built-in emulation.
+    $adoptiumUrl = "https://api.adoptium.net/v3/binary/latest/$EmbeddedVersion/ga/windows/x64/jdk/hotspot/normal/eclipse?project=jdk"
+    $zip = Join-Path ([System.IO.Path]::GetTempPath()) "starlake-embedded-jdk.zip"
+    $unpack = Join-Path ([System.IO.Path]::GetTempPath()) ("starlake-jdk-" + [System.IO.Path]::GetRandomFileName())
+    try {
+        Invoke-WebRequest -UseBasicParsing -Uri $adoptiumUrl -OutFile $zip -ErrorAction Stop
+    } catch {
+        Write-Host "Error: failed to download the embedded JDK from $adoptiumUrl"
+        Write-Host $_.Exception.Message
         exit 1
     }
-    if ($javaVersion -lt "11") {
-        Write-Host "Java version $javaVersion is not supported. Please install Java 11 or above."
+    Expand-Archive -Path $zip -DestinationPath $unpack -Force
+    Remove-Item $zip
+    # the archive unpacks as jdk-<version>+<build>\ - flatten it to <install-dir>\jdk
+    $inner = Get-ChildItem $unpack -Directory | Select-Object -First 1
+    if ($null -eq $inner -or -not (Test-Path (Join-Path $inner.FullName "bin\java.exe"))) {
+        Write-Host "Error: unexpected JDK archive layout"
         exit 1
     }
+    if (Test-Path $jdkDir) { Remove-Item $jdkDir -Recurse -Force }
+    Move-Item $inner.FullName $jdkDir
+    Remove-Item $unpack -Recurse -Force
+
+    # SESSION environment only: JAVA_HOME + PATH first, so this very install
+    # (starlake.cmd install below) and everything started from this shell use
+    # the embedded JDK. Later sessions are covered by starlake.cmd itself,
+    # which adopts <install-dir>\jdk when JAVA_HOME is not set.
+    $env:JAVA_HOME = $jdkDir
+    $env:Path = (Join-Path $jdkDir "bin") + ";" + $env:Path
+
+    $major = get_java_major_version (Join-Path $jdkDir "bin\java.exe")
+    if ($major -lt $MinVersion) {
+        Write-Host "Error: the embedded JDK did not install correctly (got version $major)"
+        exit 1
+    }
+    Write-Host "Embedded JDK $major ready: JAVA_HOME=$jdkDir (session)"
 }
 
 function main {
@@ -140,9 +217,10 @@ function main {
             $RequestedVersion = $arg.Substring(10)
         }
     }
-    check_java_version
     print_starlake_ascii_art
     $INSTALL_DIR = get_installation_directory
+    # java check needs the install dir: an embedded JDK lands in <install-dir>\jdk
+    ensure_java -InstallDir $INSTALL_DIR
     $VERSION = get_version_to_install -RequestedVersion $RequestedVersion
     install_starlake $INSTALL_DIR $VERSION
     add_starlake_to_path $INSTALL_DIR

--- a/distrib/setup.ps1
+++ b/distrib/setup.ps1
@@ -148,24 +148,42 @@ function resolve_java {
     return @{ Exe = ""; Major = 0; Source = "none" }
 }
 
+function get_required_java_version {
+    # The java floor depends on the Starlake version being installed:
+    #   up to 1.4.x (and every 0.x) -> java 11, from 1.5.0 on -> java 17.
+    # Unparseable versions get the current floor (17).
+    param([string]$SlVersion)
+    if ($SlVersion -match '^(\d+)\.(\d+)') {
+        $major = [int]$Matches[1]
+        $minor = [int]$Matches[2]
+        if ($major -lt 1 -or ($major -eq 1 -and $minor -le 4)) { return 11 }
+    }
+    return 17
+}
+
 function ensure_java {
-    # Check the installed Java (JAVA_HOME first). If none is found, or its
-    # version is below the required minimum, install an EMBEDDED portable
-    # Temurin JDK inside the starlake install directory (<install-dir>\jdk)
-    # and update the SESSION environment (JAVA_HOME + PATH). No administrator
-    # rights: portable zip + process-scoped variables only. starlake.cmd picks
-    # the embedded JDK up automatically in later sessions.
-    param([string]$InstallDir, [int]$MinVersion = 11, [int]$EmbeddedVersion = 17)
+    # Check the installed Java (JAVA_HOME first) against the floor required by
+    # the Starlake version being installed. If none is found, or its version is
+    # below that floor, install an EMBEDDED portable Temurin 17 JDK inside the
+    # starlake install directory (<install-dir>\jdk) and update the SESSION
+    # environment (JAVA_HOME + PATH). The embedded JDK is ALWAYS 17: it
+    # satisfies both floors (a newer JVM runs older-target bytecode). No
+    # administrator rights: portable zip + process-scoped variables only.
+    # starlake.cmd picks the embedded JDK up automatically in later sessions.
+    param([string]$InstallDir, [string]$SlVersion)
+
+    $MinVersion = get_required_java_version $SlVersion
+    $EmbeddedVersion = 17
 
     $java = resolve_java
     if ($java.Major -ge $MinVersion) {
-        Write-Host "Using Java $($java.Major) from $($java.Source)"
+        Write-Host "Using Java $($java.Major) from $($java.Source) (Starlake $SlVersion requires $MinVersion or above)"
         return
     }
     if ($java.Major -gt 0) {
-        Write-Host "Java $($java.Major) found via $($java.Source) but Java $MinVersion or above is required."
+        Write-Host "Java $($java.Major) found via $($java.Source) but Starlake $SlVersion requires Java $MinVersion or above."
     } else {
-        Write-Host "No Java found (checked JAVA_HOME and PATH). Java $MinVersion or above is required."
+        Write-Host "No Java found (checked JAVA_HOME and PATH). Starlake $SlVersion requires Java $MinVersion or above."
     }
 
     $jdkDir = Join-Path $InstallDir "jdk"
@@ -219,9 +237,11 @@ function main {
     }
     print_starlake_ascii_art
     $INSTALL_DIR = get_installation_directory
-    # java check needs the install dir: an embedded JDK lands in <install-dir>\jdk
-    ensure_java -InstallDir $INSTALL_DIR
     $VERSION = get_version_to_install -RequestedVersion $RequestedVersion
+    # after version resolution: the java floor depends on the Starlake version
+    # (<= 1.4 -> java 11, >= 1.5 -> java 17), and an embedded JDK would land
+    # in <install-dir>\jdk
+    ensure_java -InstallDir $INSTALL_DIR -SlVersion $VERSION
     install_starlake $INSTALL_DIR $VERSION
     add_starlake_to_path $INSTALL_DIR
     run_installation_command -InstallDir $INSTALL_DIR -Version $VERSION

--- a/distrib/starlake.cmd
+++ b/distrib/starlake.cmd
@@ -11,6 +11,13 @@ if not defined SL_ROOT (
 )
 set "SL_ROOT=!SL_ROOT:\=/!"
 
+rem Prefer the embedded JDK installed by setup.ps1 when JAVA_HOME is not set,
+rem then put that java first on the SESSION PATH: some run paths invoke bare
+rem `java`, and on corporate machines the system PATH often pins an older
+rem default Java first (user PATH entries can never outrank the system PATH).
+if not defined JAVA_HOME if exist "%SCRIPT_DIR%jdk\bin\java.exe" set "JAVA_HOME=%SCRIPT_DIR%jdk"
+if defined JAVA_HOME if exist "%JAVA_HOME%\bin\java.exe" set "PATH=%JAVA_HOME%\bin;%PATH%"
+
 if not defined HADOOP_HOME (
     set "HADOOP_HOME=%SCRIPT_DIR%bin\hadoop"
 )


### PR DESCRIPTION
## Problem

Two real-workstation findings on the Windows install path (locked-down corporate machines, no admin rights):

1. **The java check does not check java.** `(Get-Command java).Version` reads the *file version* of `java.exe` (not the runtime version) and can throw when `JAVA_HOME` points at a stale directory. Worse, the comparison is lexicographic — `"8.0..." -lt "11"` is **false** — so Java 8 passes the check and the install fails later with an opaque error.
2. **When the check (correctly) fails there is no remediation**: the installer exits and tells the user to install Java — which on a locked-down machine means an MSI they cannot run.

## Change

### `distrib/setup.ps1`

- `get_java_major_version` — parses the real `java -version` output (stderr), handling both version schemes (`"17.0.12"` → 17, `"1.8.0_292"` → 8); returns 0 for missing/broken interpreters instead of throwing.
- `resolve_java` — **`JAVA_HOME` first** (it is also what `starlake.cmd` executes), `java` from the PATH as fallback — including when `JAVA_HOME` is set but dangling (the old code threw there).
- `get_required_java_version` — the floor follows the **Starlake version being installed** (its java target moved over time: ≤ 0.6.3 → 8, 0.7 → 1.4 → 11, 1.5+ → 17): **≤ 1.4.x (and every 0.x) requires java 11, from 1.5.0 on java 17**; unparseable versions get the current floor (17).
- `ensure_java` — when the resolved java is below that floor: downloads a **portable Temurin JDK — always 17** (it satisfies both floors: a newer JVM runs older-target bytecode, and it keeps a single artifact whatever the version installed; Adoptium API zip; x64 — runs under the built-in emulation on Windows-on-ARM) into **`<install-dir>\jdk`** and updates the **session** environment (`JAVA_HOME` + PATH prepend). No administrator rights anywhere: portable zip + process-scoped variables only. `main` now resolves the Starlake version first (the floor depends on it), then runs the java check.

### `distrib/starlake.cmd`

- When `JAVA_HOME` is not set and `<install-dir>\jdk` exists, adopt it — so the embedded JDK keeps working in **every later session** without touching the user or machine environment.
- When `JAVA_HOME` is set, prepend `%JAVA_HOME%\bin` to the session PATH: some run paths invoke bare `java` (e.g. the native-loader branch), and on corporate machines the **system** PATH often pins an older default Java first — which user PATH entries can never outrank. Reproduced on a client workstation: correct bundle installed, `JAVA_HOME` set, and `java` still resolved to the machine's default JDK.

## Verification

Done on macOS under pwsh 7.4.5 (no Windows box in this loop — the client workstation that motivated this is available for validation):

- `setup.ps1` parses clean under a **Windows-1252 decode** of its raw bytes (what PowerShell 5.1 actually does with BOM-less files); both files pure ASCII.
- `get_java_major_version` exercised against a real JDK 11 plus fixtures: `"17.0.12"` → 17, `"1.8.0_292"` → 8, `"21"` → 21, garbage → 0, missing exe → 0.
- `get_required_java_version` fixtures (11/11): `0.6.3` / `0.7.0` / `1.4.0` / `1.4.9` / `1.4.0-SNAPSHOT` → 11; `1.5.0` / `1.6.0` / `1.7.0` / `1.10.0` / `2.0.0` / garbage → 17 — note `1.10.0` → 17 (numeric minor compare, not lexicographic).
- `resolve_java` falls back to PATH when `JAVA_HOME` dangles.
- Adoptium URL confirmed to 307-redirect to `OpenJDK17U-jdk_x64_windows_hotspot_*.zip`.
- `reinstall` flow untouched: it removes `versions.cmd` + `bin\spark` only, so the embedded `jdk\` survives reinstalls.
