### PR TITLE
Unix setup: parity with the Windows java handling — version-dependent floor + embedded JDK (#1692)

### DIFF
--- a/distrib/setup.sh
+++ b/distrib/setup.sh
@@ -189,34 +189,157 @@ print_success_message() {
     echo "Starlake has been successfully installed!"
 }
 
-check_java_version() {
-# Find the java binary
-    if [ -n "${JAVA_HOME}" ]; then
-      RUNNER="${JAVA_HOME}/bin/java"
+get_binary_from_url() {
+    local url=$1
+    local target_file=$2
+    local status_code
+    if [ -n "$PROXY" ] && [ -n "$SL_INSECURE" ]; then
+        echo "Downloading $url to $target_file using proxy $PROXY"
+        status_code=$(curl -L --insecure --proxy "$PROXY" -s -w "%{http_code}" -o "$target_file" "$url")
     else
-      if [ "$(command -v java)" ]; then
-        RUNNER="java"
-      else
-        echo "JAVA_HOME is not set" >&2
-        exit 1
-      fi
+        status_code=$(curl -L -s -w "%{http_code}" -o "$target_file" "$url")
     fi
-    local version=$($RUNNER -version 2>&1 | awk -F '"' '/version/ {print $2}')
-    local major=$(echo "$version" | awk -F '.' '{print $1}')
-    local minor=$(echo "$version" | awk -F '.' '{print $2}')
+    if [[ ! $status_code =~ ^2[0-9][0-9]$ ]]; then
+        echo "Error: Failed to download $url. HTTP status code: $status_code"
+        exit 1
+    fi
+}
 
-    if [[ "$major" -lt 11 ]]; then
-        echo "Error: Java 11 or later is required."
+get_java_major_version() {
+    # Parse the REAL runtime version from `java -version` (stderr), handling
+    # both version schemes: "17.0.12" -> 17, "1.8.0_292" -> 8.
+    # Prints 0 for missing/broken interpreters.
+    local exe=$1
+    local line major minor
+    line=$("$exe" -version 2>&1 | head -n 1) || true
+    if [[ "$line" =~ version\ \"([0-9]+)(\.([0-9]+))? ]]; then
+        major="${BASH_REMATCH[1]}"
+        minor="${BASH_REMATCH[3]}"
+        if [[ "$major" == "1" && -n "$minor" ]]; then
+            major="$minor"
+        fi
+        echo "$major"
+    else
+        echo 0
+    fi
+}
+
+resolve_java() {
+    # JAVA_HOME wins when it is set (that is also what the starlake launcher
+    # executes); otherwise fall back to `java` from the PATH - including when
+    # JAVA_HOME is set but points nowhere.
+    RESOLVED_JAVA_MAJOR=0
+    RESOLVED_JAVA_SOURCE="none"
+    if [ -n "${JAVA_HOME:-}" ] && [ -x "${JAVA_HOME}/bin/java" ]; then
+        RESOLVED_JAVA_MAJOR=$(get_java_major_version "${JAVA_HOME}/bin/java")
+        RESOLVED_JAVA_SOURCE="JAVA_HOME (${JAVA_HOME})"
+        return
+    fi
+    if command -v java >/dev/null 2>&1; then
+        RESOLVED_JAVA_MAJOR=$(get_java_major_version "$(command -v java)")
+        RESOLVED_JAVA_SOURCE="PATH ($(command -v java))"
+    fi
+}
+
+get_required_java_version() {
+    # The java floor depends on the Starlake version being installed:
+    #   up to 1.4.x (and every 0.x) -> java 11, from 1.5.0 on -> java 17.
+    # Unparseable versions get the current floor (17).
+    local sl_version=$1
+    local major minor
+    if [[ "$sl_version" =~ ^([0-9]+)\.([0-9]+) ]]; then
+        major="${BASH_REMATCH[1]}"
+        minor="${BASH_REMATCH[2]}"
+        if [ "$major" -lt 1 ] || { [ "$major" -eq 1 ] && [ "$minor" -le 4 ]; }; then
+            echo 11
+            return
+        fi
+    fi
+    echo 17
+}
+
+ensure_java() {
+    # Check the installed Java (JAVA_HOME first) against the floor required by
+    # the Starlake version being installed. If none is found, or its version is
+    # below that floor, install an EMBEDDED portable Temurin 17 JDK inside the
+    # starlake install directory ($INSTALL_DIR/jdk) and update the SESSION
+    # environment (JAVA_HOME + PATH). The embedded JDK is ALWAYS 17: it
+    # satisfies both floors (a newer JVM runs older-target bytecode). No root
+    # rights: portable archive + process-scoped variables only. The starlake
+    # launcher picks the embedded JDK up automatically in later sessions.
+    local min_version embedded_version=17
+    min_version=$(get_required_java_version "$VERSION")
+
+    resolve_java
+    if [ "$RESOLVED_JAVA_MAJOR" -ge "$min_version" ]; then
+        echo "Using Java $RESOLVED_JAVA_MAJOR from $RESOLVED_JAVA_SOURCE (Starlake $VERSION requires $min_version or above)"
+        return
+    fi
+    if [ "$RESOLVED_JAVA_MAJOR" -gt 0 ]; then
+        echo "Java $RESOLVED_JAVA_MAJOR found via $RESOLVED_JAVA_SOURCE but Starlake $VERSION requires Java $min_version or above."
+    else
+        echo "No Java found (checked JAVA_HOME and PATH). Starlake $VERSION requires Java $min_version or above."
+    fi
+
+    local os arch
+    case "$(uname -s)" in
+        Darwin) os=mac ;;
+        Linux)  os=linux ;;
+        *) echo "Error: unsupported OS $(uname -s) - install Java $min_version manually."; exit 1 ;;
+    esac
+    case "$(uname -m)" in
+        x86_64|amd64)  arch=x64 ;;
+        aarch64|arm64) arch=aarch64 ;;
+        *) echo "Error: unsupported architecture $(uname -m) - install Java $min_version manually."; exit 1 ;;
+    esac
+
+    local jdk_dir="$INSTALL_DIR/jdk"
+    echo "Installing an embedded Temurin $embedded_version JDK into $jdk_dir (portable archive, no root rights)"
+    local adoptium_url="https://api.adoptium.net/v3/binary/latest/$embedded_version/ga/$os/$arch/jdk/hotspot/normal/eclipse?project=jdk"
+    local archive unpack_dir top java_home_dir
+    archive=$(mktemp -t starlake-jdk.XXXXXX).tar.gz
+    unpack_dir=$(mktemp -d -t starlake-jdk.XXXXXX)
+    get_binary_from_url "$adoptium_url" "$archive"
+    tar -xzf "$archive" -C "$unpack_dir"
+    rm -f "$archive"
+    top=$(find "$unpack_dir" -mindepth 1 -maxdepth 1 -type d | head -n 1)
+    # macOS archives nest the actual JDK under Contents/Home
+    if [ -x "$top/Contents/Home/bin/java" ]; then
+        java_home_dir="$top/Contents/Home"
+    elif [ -x "$top/bin/java" ]; then
+        java_home_dir="$top"
+    else
+        echo "Error: unexpected JDK archive layout"
         exit 1
     fi
-    echo "Java version $version is detected."
+    rm -rf "$jdk_dir"
+    mv "$java_home_dir" "$jdk_dir"
+    rm -rf "$unpack_dir"
+
+    # SESSION environment only: JAVA_HOME + PATH first, so this very install
+    # (starlake install below) uses the embedded JDK. Later sessions are
+    # covered by the starlake launcher, which adopts $INSTALL_DIR/jdk when
+    # JAVA_HOME is not set.
+    export JAVA_HOME="$jdk_dir"
+    export PATH="$JAVA_HOME/bin:$PATH"
+
+    local major
+    major=$(get_java_major_version "$jdk_dir/bin/java")
+    if [ "$major" -lt "$min_version" ]; then
+        echo "Error: the embedded JDK did not install correctly (got version $major)"
+        exit 1
+    fi
+    echo "Embedded JDK $major ready: JAVA_HOME=$jdk_dir (session)"
 }
 
 main() {
-    check_java_version
     print_starlake_ascii_art
     get_installation_directory "$@"
     get_version_to_install "$@"
+    # after version resolution: the java floor depends on the Starlake version
+    # (<= 1.4 -> java 11, >= 1.5 -> java 17), and an embedded JDK would land
+    # in $INSTALL_DIR/jdk
+    ensure_java
     install_starlake
     add_starlake_to_path
     run_installation_command

--- a/distrib/starlake.sh
+++ b/distrib/starlake.sh
@@ -11,6 +11,18 @@ API_BIN_DIR="$SCRIPT_DIR/bin/api/bin"
 
 SL_ROOT="${SL_ROOT:-`pwd`}"
 
+# Prefer the embedded JDK installed by setup.sh when JAVA_HOME is not set,
+# then put that java first on the SESSION PATH: some run paths invoke bare
+# `java`, and the system PATH may pin an older default Java first.
+if [ -z "${JAVA_HOME:-}" ] && [ -x "$SCRIPT_DIR/jdk/bin/java" ]
+then
+  export JAVA_HOME="$SCRIPT_DIR/jdk"
+fi
+if [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/java" ]
+then
+  export PATH="$JAVA_HOME/bin:$PATH"
+fi
+
 case "$1" in
   reinstall)
     rm "$SCRIPT_DIR/versions.sh"


### PR DESCRIPTION
Unix setup: parity with the Windows java handling (#1692)

Brings distrib/setup.sh and distrib/starlake.sh to the same behavior as
the Windows installer merged in #1692:

setup.sh:
- get_java_major_version: parses the real `java -version` output, both
  version schemes ("17.0.12" -> 17, "1.8.0_292" -> 8); 0 for missing or
  broken interpreters instead of exiting
- resolve_java: JAVA_HOME first (what the launcher executes), PATH java
  as fallback - including when JAVA_HOME is set but dangling (the old
  check aborted with "JAVA_HOME is not set" when neither was usable, and
  its floor was a flat 11 with no remediation)
- get_required_java_version: the floor follows the Starlake version being
  installed (<= 1.4.x and every 0.x -> java 11, from 1.5.0 -> java 17;
  unparseable -> 17)
- ensure_java: below the floor -> downloads a portable Temurin 17 JDK
  (always 17: satisfies both floors) from the Adoptium API for the
  detected os/arch (mac/linux x x64/aarch64) into $INSTALL_DIR/jdk,
  flattening the macOS Contents/Home nesting, then updates the SESSION
  environment (JAVA_HOME + PATH prepend). No root rights: portable
  archive + process-scoped variables only.
- get_binary_from_url added (binary twin of get_from_url, same
  PROXY/SL_INSECURE handling)
- main reordered: version resolved first, then the java check (the floor
  depends on it)

starlake.sh:
- when JAVA_HOME is not set and $SCRIPT_DIR/jdk exists, adopt it - the
  embedded JDK keeps working in every later session without touching the
  user environment
- when JAVA_HOME is set, prepend $JAVA_HOME/bin to the session PATH
  (some run paths invoke bare `java`)

Verified on macOS (arm64) for real, not simulated:
- ensure_java end-to-end: java 11 on PATH + Starlake 1.6.0 -> floor 17
  triggered, mac/aarch64 tarball downloaded, Contents/Home flattened,
  $INSTALL_DIR/jdk/bin/java -version -> 17.0.20, session PATH resolves
  the embedded java first
- starlake.sh adoption: the modified launcher, run with JAVA_HOME unset
  in a sandbox install containing the embedded jdk, exports
  JAVA_HOME=<install>/jdk (bash -x trace) and the PATH prepend puts the
  embedded java first
- get_required_java_version fixtures 11/11 (incl. 1.10.0 -> 17, numeric
  compare); resolve_java falls back to PATH on dangling JAVA_HOME
- bash -n clean on both files; pure ASCII; all four Adoptium os/arch
  URLs return the expected redirect
