### PR TITLE
setup.ps1: java version probe dies under PowerShell 5.1 when the caller runs with ErrorActionPreference=Stop

### DIFF
--- a/distrib/setup.ps1
+++ b/distrib/setup.ps1
@@ -123,6 +123,13 @@ function get_java_major_version {
     if (-not (Test-Path $JavaExe) -and -not (Get-Command $JavaExe -ErrorAction SilentlyContinue)) {
         return 0
     }
+    # `java -version` prints to STDERR. Under Windows PowerShell 5.1, when the
+    # CALLER runs with $ErrorActionPreference = "Stop" (a dynamically scoped
+    # preference this script inherits), redirected native stderr lines become
+    # terminating NativeCommandError. Reset the preference for this scope so
+    # the version probe can never throw; stderr lines may still arrive as
+    # ErrorRecord objects, hence the explicit stringification below.
+    $ErrorActionPreference = "Continue"
     $line = & $JavaExe -version 2>&1 | Select-Object -First 1
     if ("$line" -match 'version "(\d+)(?:\.(\d+))?') {
         $major = [int]$Matches[1]


### PR DESCRIPTION
Follow-up to #1692, reported from a real Windows PowerShell 5.1 run (locked-down corporate workstation):

```text
java.exe : openjdk version "17.0.19" 2026-04-21
Au caractère ...\sl-setup.ps1:126 : 13
+     $line = & $JavaExe -version 2>&1 | Select-Object -First 1
    + FullyQualifiedErrorId : NativeCommandError
```

**Root cause** — `java -version` prints to **stderr**, and under Windows PowerShell 5.1 redirected native stderr lines (`2>&1`) become **terminating** `NativeCommandError`s when `$ErrorActionPreference` is `Stop`. The preference is *dynamically scoped*: any caller running with `Stop` (here, a wrapper script invoking `setup.ps1` in-process) silently propagates it into this script. pwsh 7 removed that behavior — which is why the probe tested green there and only died on a real 5.1.

**Fix** — reset `$ErrorActionPreference = 'Continue'` inside `get_java_major_version`; the assignment is scope-local, so the caller's preference is untouched after the call (verified). The existing `"$line"` stringification already handles stderr lines arriving as `ErrorRecord` objects.

**Verified** (pwsh 7.4.5; the 5.1 throw itself is not reproducible there): probe returns the correct major with a caller running `EAP=Stop`, caller preference intact afterwards, Windows-1252-decode parse clean, pure ASCII. The reporting workstation is the validation target.