### PR TITLE
Setup: install the pinned version without calling the GitHub API

### DIFF
--- a/distrib/setup.ps1
+++ b/distrib/setup.ps1
@@ -9,11 +9,21 @@ function print_starlake_ascii_art {
 }
 
 function get_installation_directory {
-    $INSTALL_DIR = Read-Host "Where do you want to install Starlake? [$HOME\starlake]"
+    # --target <dir> (or --target=<dir>) installs without prompting, the same
+    # contract setup.sh offers, so a scripted install always lands where the
+    # caller expects it.
+    param([string]$RequestedTarget = "")
+
+    $INSTALL_DIR = $RequestedTarget
+    if ($INSTALL_DIR -eq "") {
+        $INSTALL_DIR = Read-Host "Where do you want to install Starlake? [$HOME\starlake]"
+    }
     if ($INSTALL_DIR -eq "") {
         $INSTALL_DIR = "$HOME\starlake"
     }
-    $INSTALL_DIR = Invoke-Expression "Write-Output $INSTALL_DIR"
+    # expand any variable the user typed ($HOME, $env:USERPROFILE); the inner
+    # quotes keep a path with spaces a single argument
+    $INSTALL_DIR = Invoke-Expression "Write-Output `"$INSTALL_DIR`""
     New-Item -ItemType Directory -Path $INSTALL_DIR -Force | Out-Null
     $INSTALL_DIR
 }
@@ -22,7 +32,18 @@ function get_installation_directory {
 function get_version_to_install {
     param([string]$RequestedVersion = "")
 
+    # An explicitly requested version is authoritative: install it as asked and
+    # never call the GitHub API (same contract as setup.sh). The API is only
+    # needed to build the interactive menu. Locked-down corporate networks
+    # routinely reach raw.githubusercontent.com but block or rate-limit
+    # api.github.com (60 requests/hour per egress IP, shared by the whole NAT),
+    # and a pinned install has nothing to ask about.
+    if ($RequestedVersion -ne "") {
+        return $RequestedVersion
+    }
+
     $RELEASE_VERSIONS = @()
+    $apiError = ""
     try {
         $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/starlake-ai/starlake/releases?per_page=15" -UseBasicParsing
         $RELEASE_VERSIONS = @($releases |
@@ -31,10 +52,18 @@ function get_version_to_install {
             ForEach-Object { $_.TrimStart('v') } |
             Sort-Object -Descending { [version]$_ } |
             Select-Object -First 5)
-    } catch {}
+    } catch {
+        $apiError = $_.Exception.Message
+    }
 
     if ($RELEASE_VERSIONS.Count -eq 0) {
         Write-Host "Error: no releases found at https://github.com/starlake-ai/starlake/releases"
+        # never swallow the cause: a proxy refusal, a TLS failure and an API
+        # rate limit all reach this line and need different remedies
+        if ($apiError -ne "") {
+            Write-Host "Cause: $apiError"
+        }
+        Write-Host "If this network blocks api.github.com, pass the version explicitly, e.g. --version=1.7.1"
         exit 1
     }
 
@@ -83,14 +112,27 @@ function install_starlake {
 }
 
 function add_starlake_to_path {
-    param([string]$x)
-    if (!($env:PATH -split ';' -contains $X)){
+    param([string]$x, [bool]$NonInteractive = $false)
+    if (!($env:PATH -split ';' -contains $x)){
         $Env:Path+= ";" +  $x
-        Write-Output $Env:Path
-        $write = Read-Host 'Set PATH permanently ? (yes|no)'
+        # a scripted install (--target=) persists the PATH the way setup.sh
+        # does for the shell rc file: without asking
+        if ($NonInteractive) {
+            $write = "yes"
+        } else {
+            Write-Output $Env:Path
+            $write = Read-Host 'Set PATH permanently ? (yes|no)'
+        }
         if ($write -eq "yes")
         {
-            [Environment]::SetEnvironmentVariable("Path",$env:Path, [System.EnvironmentVariableTarget]::User)
+            # append to the USER PATH, never write $env:Path back: the process
+            # PATH is "system + user", so storing it in the user scope copies
+            # the whole machine PATH there and freezes a stale copy of it
+            $userPath = [Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::User)
+            if (($userPath -split ';') -notcontains $x) {
+                $userPath = if ($userPath) { "$userPath;$x" } else { $x }
+                [Environment]::SetEnvironmentVariable("Path", $userPath, [System.EnvironmentVariableTarget]::User)
+            }
             Write-Output 'PATH updated'
         }
     }
@@ -237,20 +279,45 @@ function ensure_java {
 function main {
     param([string[]]$ScriptArgs = @())
     $RequestedVersion = ""
-    foreach ($arg in $ScriptArgs) {
-        if ($arg.StartsWith("--version=")) {
-            $RequestedVersion = $arg.Substring(10)
+    $RequestedTarget = ""
+    # Both "--opt value" and "--opt=value" are accepted. The separate-token form
+    # is the only one that survives PowerShell for a Windows PATH: PowerShell
+    # reads an unquoted token starting with "-" as parameter syntax and splits
+    # it at the first colon, so `--target=C:\sl` arrives as `--target=C` plus
+    # `\sl` - which would silently install into a directory named "C". Rejoin
+    # that split rather than obeying it.
+    for ($i = 0; $i -lt $ScriptArgs.Count; $i++) {
+        $arg = $ScriptArgs[$i]
+        $name = ""
+        $value = ""
+        if ($arg -match '^(--[a-z]+)=(.*)$') {
+            $name = $Matches[1]
+            $value = $Matches[2]
+            # drive letter torn off by PowerShell's -name:value parsing
+            if ($value -match '^[A-Za-z]$' -and ($i + 1) -lt $ScriptArgs.Count -and $ScriptArgs[$i + 1] -match '^[\\/]') {
+                $value = $value + ":" + $ScriptArgs[$i + 1]
+                $i++
+            }
+        }
+        elseif ($arg -match '^(--[a-z]+)$' -and ($i + 1) -lt $ScriptArgs.Count) {
+            $name = $Matches[1]
+            $value = $ScriptArgs[$i + 1]
+            $i++
+        }
+        switch ($name) {
+            "--version" { $RequestedVersion = $value }
+            "--target"  { $RequestedTarget = $value }
         }
     }
     print_starlake_ascii_art
-    $INSTALL_DIR = get_installation_directory
+    $INSTALL_DIR = get_installation_directory -RequestedTarget $RequestedTarget
     $VERSION = get_version_to_install -RequestedVersion $RequestedVersion
     # after version resolution: the java floor depends on the Starlake version
     # (<= 1.4 -> java 11, >= 1.5 -> java 17), and an embedded JDK would land
     # in <install-dir>\jdk
     ensure_java -InstallDir $INSTALL_DIR -SlVersion $VERSION
     install_starlake $INSTALL_DIR $VERSION
-    add_starlake_to_path $INSTALL_DIR
+    add_starlake_to_path $INSTALL_DIR ($RequestedTarget -ne "")
     run_installation_command -InstallDir $INSTALL_DIR -Version $VERSION
     print_success_message
 }


### PR DESCRIPTION
Reported from a locked-down corporate Windows workstation, installing the Starlake CLI 1.7.1 with the version pinned on the command line:

```
==> Starlake CLI 1.7.1 (installs its own embedded JDK if java is missing/too old)
Where do you want to install Starlake? [C:\Users\xxx\starlake]: C:\Users\xxx\Desktop\Starlake
Error: no releases found at https://github.com/starlake-ai/starlake/releases
starlake setup.ps1 failed (exit 1)
```

## The parity gap

`setup.sh` returns from `get_version_to_install` the moment `--version=` is present and never touches GitHub:

```bash
if [[ -n "$VERSION" ]]; then
    return
fi
```

`setup.ps1` always called `api.github.com/repos/starlake-ai/starlake/releases?per_page=15`, and additionally required the requested version to appear in the **last five** releases — otherwise it dropped into an interactive menu a scripted install cannot answer.

That machine reaches `raw.githubusercontent.com` (`setup.ps1` itself, and the graphviz zip, downloaded fine) but not the API host. Unauthenticated GitHub allows 60 requests/hour **per egress IP**, shared by everyone behind the same corporate NAT, so both a category block and a rate limit produce this. `catch {}` hid which one.

The five-release window is a second failure mode independent of any proxy: every pin breaks as soon as five newer releases exist.

## Changes, all in `distrib/setup.ps1`

- **An explicit `--version` short-circuits the API**, matching `setup.sh`. The API is only consulted to build the interactive menu.
- When the menu *is* needed, the failure prints the actual exception and the remedy instead of swallowing it.
- **`--target <dir>`** installs without prompting (`setup.sh` has had `--target=` all along) and persists the PATH without asking, the way `setup.sh` writes the shell rc file.
- **Both `--opt value` and `--opt=value` are accepted, and a torn drive letter is rejoined.** PowerShell parses an unquoted token starting with `-` as `-name:value` and cuts it at the first colon, so `--target=C:\sl` reaches the script as `--target=C` plus `\sl` — it would have silently installed into a directory named `C`. A path must travel as a separate token; the parser now handles either spelling.
- **`add_starlake_to_path` no longer copies the machine PATH into the user scope.** It wrote `$env:Path` — the whole process PATH, which is *system + user* — into `EnvironmentVariableTarget::User`, so every Windows install froze a stale copy of the system PATH into the user variable. It now appends the install directory to the user PATH only.
- The install directory is expanded through a **quoted** `Invoke-Expression`, so a path containing spaces stays one argument.

## Verification

`pwsh` harness driving the real `main`, with `Invoke-RestMethod` and `Read-Host` mocked to throw so any API call or prompt fails the test:

| case | result |
| --- | --- |
| pinned `--version=1.7.1` | resolves, no API call, no prompt |
| pinned version outside the top 5 (`1.5.16`) | accepted (used to loop on an unanswerable menu) |
| `--version=1.7.1 --target C:\Users\x\starlake` | dir `C:\Users\x\starlake` |
| `--target=C` + `\Users\x\starlake` (as PowerShell tears it apart) | rejoined to `C:\Users\x\starlake` |
| `--target=C:\sl` arriving intact (cmd.exe, `-Command`) | `C:\sl` |
| `--target=sl-here`, `--target \\srv\share\sl` | unchanged, nothing rejoined |
| `--target=C` with no path after it | stays `C` |
| flags reversed, both in space form | resolve |
| target with spaces / trailing backslash | preserved |
| no `--target` | still prompts for directory and PATH |
| API failure with no `--version` | exits 1, naming the cause |

Before/after reproduction with the API mocked as `403 Forbidden`: the current script dies with `Error: no releases found` despite `--version=1.7.1`; the patched one proceeds to `ensure_java`.

Every `.ps1` still parses under a Windows-1252 decode of its raw bytes (the PowerShell 5.1 simulation) and the file stays pure ASCII.

Follows #1692 / #1693 / #1694 / #1695 / #1696 in the same series: making the installation work, and fail honestly, on locked-down corporate machines.
