### PR TITLE
chore: fix stale references surfaced by the naming audit

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,7 +10,7 @@ assignees: ''
 ## Description
 Add here a clear and concise  description of the suggested feature. 
 Is your feature request related to a problem? Please describe.
-Is this feature related to any client using Comet? How?
+Is this feature related to any client using Starflow? How?
 
 ## Solution proposition
 A clear and concise description of what you want to happen.

--- a/api-env-vars.md
+++ b/api-env-vars.md
@@ -18,7 +18,7 @@ This document describes all environment variables that can be used to configure 
 | `SL_API_APP_TYPE` | Application type: `web`, `snowflake_native_app`, `bigquery_native_app`, `redshift_native_app` | `web` |
 | `SL_API_MAX_AGE_MINUTES` | Session maximum age in minutes | `120` |
 | `SL_API_MODE` | API mode: `LOCAL` (on-premise auth), `CLOUD` (cloud auth), `ALL` (both), `SAAS` (multitenant) | `LOCAL` |
-| `SL_API_UI_FOLDER` | Path where static UI files are located | `/Users/hayssams/git/starlake-api/ui` |
+| `SL_API_UI_FOLDER` | Path where static UI files are located | `/path/to/starlake-api/ui` |
 | `SL_API_DAG_FOLDER` | Relative path to project-root where DAGs are generated | `dags` |
 | `SL_API_DOCS_USER` | Username for accessing the docs (alias: `SL_API_DOCS_USERS`) | `starlake` |
 | `SL_API_DOCS_PASSWORD` | Password for accessing the docs | `s3cret.Paw` |

--- a/build.sbt
+++ b/build.sbt
@@ -321,7 +321,6 @@ packageSetup := {
     manifest.getMainAttributes().putValue("Manifest-Version", "1.0")
     manifest.getMainAttributes().putValue("Implementation-Version", version.value)
     manifest.getMainAttributes().putValue("Implementation-Vendor", "starlake")
-    manifest.getMainAttributes().putValue("Implementation-Vendor", "starlake")
     manifest.getMainAttributes().putValue("Compiler-Version", javacCompilerVersion)
 
     IO.jar(from.map(f => f.toFile -> f.toFile.getName()), to.toFile, manifest)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,4 @@
 ignore:
   - "src/main/scala/ai/starlake/job/Main"
   - "src/main/scala/ai/starlake/repl/Main.scala"
-  - "src/main/scala/com/ebiznext/comet/job/Main.scala"
   - "src/main/scala/ai/starlake/serve/SingleUserMainServer.scala"

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -250,7 +250,7 @@ REST API server mode (`starlake serve`) for integration with UIs and external sy
 
 ### 4.4 Library
 
-Published to Maven Central as `ai.starlake:starlake-core_2.13`. Embeddable in Spark applications.
+Published to GitHub Releases as `ai.starlake:starlake-core_2.13`. Embeddable in Spark applications.
 
 ---
 


### PR DESCRIPTION
Five pre-existing defects found during the Task 1 naming audit, independent of the rename itself:

- `.github/ISSUE_TEMPLATE/feature_request.md` still asked reporters about **Comet**, the pre-Starlake product name
- `codecov.yml` ignored the dead Comet-era path `src/main/scala/com/ebiznext/comet/job/Main.scala`
- `build.sbt` set `Implementation-Vendor` twice with byte-identical lines
- `api-env-vars.md` documented a local absolute path (`/Users/hayssams/...`) as the `SL_API_UI_FOLDER` default; replaced with a neutral placeholder
- `docs/PRD.md` said "Published to Maven Central"; publishing moved to GitHub Releases in July 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWLuy2yBXT6ynzrrzapdjr
