### PR TITLE
chore: canonicalize repo slug in release tooling

### DIFF
--- a/.github/workflows/snapshot-jar-only.yml
+++ b/.github/workflows/snapshot-jar-only.yml
@@ -46,10 +46,10 @@ jobs:
           test -f "$JAR"
           ( cd target/scala-2.13 && shasum -a 256 "starlake-core_2.13-${V}-assembly.jar" > "starlake-core_2.13-${V}-assembly.jar.sha256" )
           TAG="v${V}"
-          gh release view "$TAG" --repo starlake-ai/starlake >/dev/null 2>&1 \
-            || gh release create "$TAG" --repo starlake-ai/starlake --prerelease \
+          gh release view "$TAG" --repo starlake-ai/starflow >/dev/null 2>&1 \
+            || gh release create "$TAG" --repo starlake-ai/starflow --prerelease \
                  --title "$TAG" --notes "Rolling snapshot build. Assets are overwritten on every snapshot publish."
-          gh release upload "$TAG" "$JAR" "${JAR}.sha256" --repo starlake-ai/starlake --clobber
+          gh release upload "$TAG" "$JAR" "${JAR}.sha256" --repo starlake-ai/starflow --clobber
       - name: trigger-starlake-api
         if: ${{ success() }}
         uses: actions/github-script@v6

--- a/scripts/local-release.sh
+++ b/scripts/local-release.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # (distribution moved off Maven Central), then bumps all version references
 # to the next SNAPSHOT.
 #
-# Each release is a tag v{X.Y.Z} on starlake-ai/starlake carrying 4 assets:
+# Each release is a tag v{X.Y.Z} on starlake-ai/starflow carrying 4 assets:
 #   starlake-core_{scala}-{v}-assembly.jar (+ .sha256)
 #   starlake-api_{scala}-{v}.zip           (+ .sha256)
 #

--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -9,7 +9,7 @@
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 SCALA_VERSION="${SCALA_VERSION:-2.13}"
-GH_REPO="starlake-ai/starlake"
+GH_REPO="starlake-ai/starflow"
 
 # ---- preflight helpers ----------------------------------------------------
 die() { echo "ERROR: $*" >&2; exit 1; }


### PR DESCRIPTION
Follow-up to the starlake -> starflow repo rename: updates the 5 internal references in scripts/{local-release,release-lib}.sh and .github/workflows/snapshot-jar-only.yml plus the GH_REPO constant, so release tooling stops depending on the GitHub redirect.

Untouched: starlake-api sibling repo dispatch targets, Maven paths (ai/starlake/...), Docker image names (starlakeai/starlake), and the Discord announcement URLs (user-visible, moved to the gated #1718 instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWLuy2yBXT6ynzrrzapdjr