### PR TITLE
fix: backtick the tables/<table>.tmdl placeholder in semantic-export help

### DIFF
--- a/src/main/scala/ai/starlake/semantic/SemanticExportCmd.scala
+++ b/src/main/scala/ai/starlake/semantic/SemanticExportCmd.scala
@@ -44,7 +44,7 @@ object SemanticExportCmd extends Cmd[SemanticExportConfig] {
           |format. Supported formats: ossie (Apache Ossie, incubating), lookml (a Looker
           |project: one view file per table plus a model file with explores) and tmdl
           |(a Power BI TMDL folder: database.tmdl, model.tmdl, relationships.tmdl and
-          |one tables/<table>.tmdl per table).
+          |one `tables/<table>.tmdl` per table).
           |
           |For ossie, Starflow-specific attributes with no Ossie counterpart are
           |preserved in custom_extensions blocks under the STARLAKE vendor name.


### PR DESCRIPTION
Companion to starlake-ai/starlake-docs#31. The semantic-export long description contains a literal tables/<table>.tmdl; the CLI descriptions are rendered into the docs site as MDX, where a bare <table> parses as an unclosed JSX tag and fails the entire docs build (this broke the docs deploy after the last cli regeneration). Backticking the placeholder keeps every future regeneration MDX-safe, and reads better in --help too.

Scanned all other command descriptions for unescaped angle-bracket tokens: this was the only one. sbt compile green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWLuy2yBXT6ynzrrzapdjr