### PR TITLE
fix: prefix guide links in CLI help with /starflow

### DIFF
--- a/src/main/scala/ai/starlake/extract/ExtractDataCmd.scala
+++ b/src/main/scala/ai/starlake/extract/ExtractDataCmd.scala
@@ -29,7 +29,7 @@ trait ExtractDataCmd extends Cmd[UserExtractDataConfig] {
       builder.head(shell, command, "[options]"),
       builder.note(
         """
-          |Extract data from a JDBC database into CSV or Parquet files. Supports incremental extraction, parallel partitioning, and selective table filtering for efficient large-scale data exports. See [Extract Tutorial](/guides/extract/tutorial).
+          |Extract data from a JDBC database into CSV or Parquet files. Supports incremental extraction, parallel partitioning, and selective table filtering for efficient large-scale data exports. See [Extract Tutorial](/starflow/guides/extract/tutorial).
           |
           |Extract data from any database defined in mapping file.
           |

--- a/src/main/scala/ai/starlake/extract/ExtractSchemaCmd.scala
+++ b/src/main/scala/ai/starlake/extract/ExtractSchemaCmd.scala
@@ -27,7 +27,7 @@ object ExtractSchemaCmd extends Cmd[ExtractSchemaConfig] {
       builder.programName(s"$shell $command"),
       builder.head(shell, command, "[options]"),
       builder.note(
-        """Extract table schemas from a JDBC database and generate Starflow YAML configuration files. Use this to reverse-engineer existing database tables into domain definitions with optional snake_case naming. See [Extract Tutorial](/guides/extract/tutorial)."""
+        """Extract table schemas from a JDBC database and generate Starflow YAML configuration files. Use this to reverse-engineer existing database tables into domain definitions with optional snake_case naming. See [Extract Tutorial](/starflow/guides/extract/tutorial)."""
       ),
       builder
         .opt[String]("config")

--- a/src/main/scala/ai/starlake/job/bootstrap/BootstrapCmd.scala
+++ b/src/main/scala/ai/starlake/job/bootstrap/BootstrapCmd.scala
@@ -28,7 +28,7 @@ object BootstrapCmd extends Cmd[BootstrapConfig] {
       builder.head(shell, command, "[options]"),
       builder.note(
         """
-          |Create a new Starflow project from a template. Generates the required directory structure and sample configuration files to get started quickly. See [Project Setup Guide](/guides/project-setup/starlake-project-setup).
+          |Create a new Starflow project from a template. Generates the required directory structure and sample configuration files to get started quickly. See [Project Setup Guide](/starflow/guides/project-setup/starlake-project-setup).
           |
           |Create a new project optionally based on a specific template eq. quickstart / userguide
           |""".stripMargin

--- a/src/main/scala/ai/starlake/job/infer/InferSchemaCmd.scala
+++ b/src/main/scala/ai/starlake/job/infer/InferSchemaCmd.scala
@@ -31,7 +31,7 @@ object InferSchemaCmd extends Cmd[InferSchemaConfig] with LazyLogging {
       builder.programName(s"$shell $command"),
       builder.head(shell, command, "[options]"),
       builder.note(
-        """Infer a Starflow table schema from a sample data file (CSV, JSON, etc.) and generate the corresponding YAML configuration. See [Load Tutorial](/guides/load/tutorial)."""
+        """Infer a Starflow table schema from a sample data file (CSV, JSON, etc.) and generate the corresponding YAML configuration. See [Load Tutorial](/starflow/guides/load/tutorial)."""
       ),
       builder
         .opt[String]("domain")

--- a/src/main/scala/ai/starlake/job/ingest/AutoLoadCmd.scala
+++ b/src/main/scala/ai/starlake/job/ingest/AutoLoadCmd.scala
@@ -29,7 +29,7 @@ trait AutoLoadCmd extends Cmd[AutoLoadConfig] with LazyLogging {
       builder.programName(s"$shell $command"),
       builder.head(shell, command, "[options]"),
       builder.note(
-        """Automatically infer schemas from files in the incoming directory and load them into the data warehouse in a single step. This combines the `infer-schema` and `load` commands, making it ideal for quick ingestion of new data sources. See [Autoload Guide](/guides/load/autoload)."""
+        """Automatically infer schemas from files in the incoming directory and load them into the data warehouse in a single step. This combines the `infer-schema` and `load` commands, making it ideal for quick ingestion of new data sources. See [Autoload Guide](/starflow/guides/load/autoload)."""
       ),
       builder
         .opt[Seq[String]]("domains")

--- a/src/main/scala/ai/starlake/job/ingest/LoadCmd.scala
+++ b/src/main/scala/ai/starlake/job/ingest/LoadCmd.scala
@@ -27,7 +27,7 @@ trait LoadCmd extends Cmd[LoadConfig] {
       builder.programName(s"$shell $command"),
       builder.head(shell, command, "[options]"),
       builder.note(
-        """Load data files from the pending directory into the data warehouse using schema definitions. See [Load Tutorial](/guides/load/tutorial)."""
+        """Load data files from the pending directory into the data warehouse using schema definitions. See [Load Tutorial](/starflow/guides/load/tutorial)."""
       ),
       builder
         .opt[Seq[String]]("domains")

--- a/src/main/scala/ai/starlake/job/metrics/MetricsCmd.scala
+++ b/src/main/scala/ai/starlake/job/metrics/MetricsCmd.scala
@@ -27,7 +27,7 @@ object MetricsCmd extends Cmd[MetricsConfig] {
       builder.programName(s"$shell $command"),
       builder.head(shell, command, "[options]"),
       builder.note(
-        """Compute data quality metrics (continuous, discrete, and frequency metrics) on loaded tables. See [Metrics Guide](/guides/load/metrics)."""
+        """Compute data quality metrics (continuous, discrete, and frequency metrics) on loaded tables. See [Metrics Guide](/starflow/guides/load/metrics)."""
       ),
       builder
         .opt[String]("domain")

--- a/src/main/scala/ai/starlake/job/site/SiteCmd.scala
+++ b/src/main/scala/ai/starlake/job/site/SiteCmd.scala
@@ -29,7 +29,7 @@ object SiteCmd extends Cmd[SiteConfig] {
       builder.head(shell, command, "[options]"),
       builder.note(
         """
-          |Generate a documentation portal from your Starflow project metadata (schemas, tasks, lineage). See [Site Builder Guide](/guides/documentation/starlake-site-builder).
+          |Generate a documentation portal from your Starflow project metadata (schemas, tasks, lineage). See [Site Builder Guide](/starflow/guides/documentation/starlake-site-builder).
           |
           |Generate site
           |""".stripMargin

--- a/src/main/scala/ai/starlake/job/transform/TransformCmd.scala
+++ b/src/main/scala/ai/starlake/job/transform/TransformCmd.scala
@@ -27,7 +27,7 @@ trait TransformCmd extends Cmd[TransformConfig] {
       builder.programName(s"$shell $command"),
       builder.head(shell, command, "[options]"),
       builder.note(
-        """Execute a SQL or Python transformation task. Starflow resolves dependencies, compiles queries with variable substitutions, and writes results to the target table. Use `--recursive` for upstream dependencies. See [Transform Guide](/guides/transform/tutorial)."""
+        """Execute a SQL or Python transformation task. Starflow resolves dependencies, compiles queries with variable substitutions, and writes results to the target table. Use `--recursive` for upstream dependencies. See [Transform Guide](/starflow/guides/transform/tutorial)."""
       ),
       builder
         .opt[String]("action")

--- a/src/main/scala/ai/starlake/schema/generator/DagDeployCmd.scala
+++ b/src/main/scala/ai/starlake/schema/generator/DagDeployCmd.scala
@@ -26,7 +26,7 @@ object DagDeployCmd extends Cmd[DagDeployConfig] {
       builder.programName(s"$shell $command"),
       builder.head(shell, command, "[options]"),
       builder.note(
-        """Deploy generated DAG files and their library dependencies to the orchestrator's DAG directory. Run this after `dag-generate` to publish workflow definitions to Airflow or another scheduler. See [Orchestration Guide](/guides/orchestrate/tutorial)."""
+        """Deploy generated DAG files and their library dependencies to the orchestrator's DAG directory. Run this after `dag-generate` to publish workflow definitions to Airflow or another scheduler. See [Orchestration Guide](/starflow/guides/orchestrate/tutorial)."""
       ),
       builder
         .opt[String]("inputDir")

--- a/src/main/scala/ai/starlake/schema/generator/DagGenerateCmd.scala
+++ b/src/main/scala/ai/starlake/schema/generator/DagGenerateCmd.scala
@@ -26,7 +26,7 @@ object DagGenerateCmd extends Cmd[DagGenerateConfig] {
       builder.programName(s"$shell $command"),
       builder.head(shell, command, "[options]"),
       builder.note(
-        """Generate Airflow or Dagster DAG files from Starflow task and domain definitions. The command analyzes SQL dependencies to produce correctly ordered workflow graphs, with optional tag filtering. See [Orchestration Guide](/guides/orchestrate/tutorial)."""
+        """Generate Airflow or Dagster DAG files from Starflow task and domain definitions. The command analyzes SQL dependencies to produce correctly ordered workflow graphs, with optional tag filtering. See [Orchestration Guide](/starflow/guides/orchestrate/tutorial)."""
       ),
       builder
         .opt[String]("outputDir")

--- a/src/main/scala/ai/starlake/tests/StarlakeTestCmd.scala
+++ b/src/main/scala/ai/starlake/tests/StarlakeTestCmd.scala
@@ -27,7 +27,7 @@ trait StarlakeTestCmd extends Cmd[StarlakeTestConfig] {
       builder.programName(s"$shell $command"),
       builder.head(shell, command, "[options]"),
       builder.note(
-        """Run unit tests for load and transform tasks using sample data and expected results. See [Unit Tests Guide](/guides/unit-tests/concepts)."""
+        """Run unit tests for load and transform tasks using sample data and expected results. See [Unit Tests Guide](/starflow/guides/unit-tests/concepts)."""
       ),
       builder
         .opt[Unit]("load")


### PR DESCRIPTION
Part of the docs restructure (umbrella landing at docs.starlake.ai, Starflow docs under /starflow, QoD under /qod). The 12 guide links embedded in command descriptions render into the generated CLI docs pages and need the /starflow prefix; old paths keep working via the _redirects file shipping with the docs site. Image links stay at the site root. sbt compile green.

Merge together with #1720 before the next cli-docs regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWLuy2yBXT6ynzrrzapdjr