### PR TITLE
backport(1.8): OVERWRITE inserts by name, sync-apply hint, syncSqlWithYaml

### DIFF
--- a/src/main/resources/reference-general.conf
+++ b/src/main/resources/reference-general.conf
@@ -298,7 +298,7 @@ maxInteractiveRecords = ${?SL_MAX_INTERACTIVE_RECORDS}
 
 
 syncSqlWithYaml = false
-#syncSqlWithYaml = ${?SL_SYNC_SQL_WITH_YAML}
+syncSqlWithYaml = ${?SL_SYNC_SQL_WITH_YAML}
 
 syncYamlWithDb = true
 syncYamlWithDb = ${?SL_SYNC_YAML_WITH_DB}

--- a/src/main/resources/templates/write-strategies/duckdb/overwrite.j2
+++ b/src/main/resources/templates/write-strategies/duckdb/overwrite.j2
@@ -3,5 +3,5 @@ DROP MATERIALIZED VIEW IF EXISTS {{ tableFullName }};
 CREATE MATERIALIZED VIEW {{ tableFullName }} AS {{ selectStatement }}
 {% else %}
 TRUNCATE TABLE {{ tableFullName }};
-INSERT INTO {{ tableFullName }} {{ selectStatement }}
+INSERT INTO {{ tableFullName }}({{ tableColumnsCsv }}) {{ selectStatement }}
 {% endif %}

--- a/src/main/resources/templates/write-strategies/jdbc/overwrite.j2
+++ b/src/main/resources/templates/write-strategies/jdbc/overwrite.j2
@@ -3,5 +3,5 @@ DROP MATERIALIZED VIEW IF EXISTS {{ tableFullName }};
 CREATE MATERIALIZED VIEW {{ tableFullName }} AS {{ selectStatement }}
 {% else %}
 TRUNCATE TABLE {{ tableFullName }};
-INSERT INTO {{ tableFullName }} {{ selectStatement }}
+INSERT INTO {{ tableFullName }}({{ tableColumnsCsv }}) {{ selectStatement }}
 {% endif %}

--- a/src/main/resources/templates/write-strategies/postgresql/overwrite.j2
+++ b/src/main/resources/templates/write-strategies/postgresql/overwrite.j2
@@ -3,5 +3,5 @@ DROP MATERIALIZED VIEW IF EXISTS {{ tableFullName }};
 CREATE MATERIALIZED VIEW {{ tableFullName }} AS {{ selectStatement }}
 {% else %}
 TRUNCATE TABLE {{ tableFullName }};
-INSERT INTO {{ tableFullName }} {{ selectStatement }}
+INSERT INTO {{ tableFullName }}({{ tableColumnsCsv }}) {{ selectStatement }}
 {% endif %}

--- a/src/main/resources/templates/write-strategies/redshift/overwrite.j2
+++ b/src/main/resources/templates/write-strategies/redshift/overwrite.j2
@@ -6,7 +6,7 @@ DROP MATERIALIZED VIEW IF EXISTS {{ tableFullName }};
 CREATE MATERIALIZED VIEW {{ tableFullName }} AS SELECT {{ tableColumnsCsv }} FROM #SL_INCOMING;
 {% else %}
 TRUNCATE TABLE {{ tableFullName }};
-INSERT INTO {{ tableFullName }} SELECT {{ tableColumnsCsv }} FROM #SL_INCOMING;
+INSERT INTO {{ tableFullName }}({{ tableColumnsCsv }}) SELECT {{ tableColumnsCsv }} FROM #SL_INCOMING;
 {% endif %}
 
 DROP VIEW IF EXISTS #SL_INCOMING;

--- a/src/main/resources/templates/write-strategies/snowflake/overwrite.j2
+++ b/src/main/resources/templates/write-strategies/snowflake/overwrite.j2
@@ -5,5 +5,5 @@ DROP MATERIALIZED VIEW IF EXISTS {{ tableFullName }};
 CREATE MATERIALIZED VIEW {{ tableFullName }} AS {{ selectStatement }}
 {% else %}
 TRUNCATE TABLE {{ tableFullName }};
-INSERT INTO {{ tableFullName }} {{ selectStatement }}
+INSERT INTO {{ tableFullName }}({{ tableColumnsCsv }}) {{ selectStatement }}
 {% endif %}

--- a/src/main/resources/templates/write-strategies/spark/overwrite.j2
+++ b/src/main/resources/templates/write-strategies/spark/overwrite.j2
@@ -4,8 +4,8 @@ DROP MATERIALIZED VIEW IF EXISTS {{ tableFullName }};
 CREATE MATERIALIZED VIEW {{ tableFullName }} AS {{ selectStatement }}
 {% elif tableFormat == 'delta' %}
 DELETE FROM {{ tableFullName }};
-INSERT INTO {{ tableFullName }} {{ selectStatement }}
+INSERT INTO {{ tableFullName }}({{ tableColumnsCsv }}) {{ selectStatement }}
 {% else %}
 TRUNCATE TABLE {{ tableFullName }};
-INSERT INTO {{ tableFullName }} {{ selectStatement }}
+INSERT INTO {{ tableFullName }}({{ tableColumnsCsv }}) {{ selectStatement }}
 {% endif %}

--- a/src/main/scala/ai/starlake/job/transform/AutoTask.scala
+++ b/src/main/scala/ai/starlake/job/transform/AutoTask.scala
@@ -243,7 +243,8 @@ abstract class AutoTask(
                  |To add the missing column(s) to the table, sync the task attributes from your SQL, then re-run the transform:
                  |  starlake transform --name $taskName --sync-apply
                  |  starlake transform --name $taskName
-                 |Alternatively, declare the new column(s) in the attributes section of the task's .sl.yml.
+                 |Alternatively, declare the new column(s) in the attributes section of the task's .sl.yml,
+                 |or set SL_SYNC_SQL_WITH_YAML=true to keep the YAML in sync with the SQL automatically.
                  |Underlying error: ${Option(cause.getMessage).getOrElse(
                   cause.toString
                 )}""".stripMargin,

--- a/src/main/scala/ai/starlake/job/transform/AutoTask.scala
+++ b/src/main/scala/ai/starlake/job/transform/AutoTask.scala
@@ -444,17 +444,29 @@ abstract class AutoTask(
           jdbcRunEngine,
           sinkConfig
         )
-        val updatedTaskDesc = taskDesc
-
-        /*
+        // When syncSqlWithYaml is enabled (SL_SYNC_SQL_WITH_YAML=true), align the task's YAML
+        // attributes with the SQL before running, so that a column added to the SELECT flows into
+        // the schema-sync ALTERs below without a manual `transform --sync-apply`. Only for
+        // user-invoked transforms (syncSchema), never for audit tables (recursion). A sync failure
+        // must not kill an otherwise runnable transform: fall back to the task as declared.
+        val updatedTaskDesc =
           if (
             this.syncSchema && settings.appConfig.syncSqlWithYaml && taskDesc._auditTableName.isEmpty
           ) {
-            val list = schemaHandler.syncPreviewSqlWithDb(taskDesc.fullName(), None, None)
-            schemaHandler.syncApplySqlWithYaml(taskDesc, list, None)
+            Try {
+              val list = schemaHandler.syncPreviewSqlWithDb(taskDesc.fullName(), None, accessToken)
+              schemaHandler.syncApplySqlWithYaml(taskDesc, list, None)
+            } match {
+              case Success(synced) => synced
+              case Failure(e) =>
+                logger.warn(
+                  s"syncSqlWithYaml: could not sync YAML attributes from SQL for task ${taskDesc
+                      .fullName()}, running with the declared attributes. Cause: ${e.getMessage}"
+                )
+                taskDesc
+            }
           } else
             taskDesc
-         */
 
         // synched if ready for sync and syncYamlWithDb is true (SL_SYNC_YAML_WITH_DB=true) and not an audit table (to avoid recursion)
         if (

--- a/src/main/scala/ai/starlake/job/transform/AutoTask.scala
+++ b/src/main/scala/ai/starlake/job/transform/AutoTask.scala
@@ -301,7 +301,8 @@ abstract class AutoTask(
     *
     * ==Write Strategies==
     *   - APPEND: INSERT INTO ... SELECT ...
-    *   - OVERWRITE: CREATE OR REPLACE TABLE ... AS SELECT ...
+    *   - OVERWRITE: TRUNCATE TABLE ...; INSERT INTO ... (columns) SELECT ... (CREATE TABLE ... AS
+    *     SELECT on the first run, when the target table does not exist yet)
     *   - MERGE: MERGE INTO ... USING ... ON ... WHEN MATCHED/NOT MATCHED
     *   - SCD2: Slowly Changing Dimension Type 2 with start/end timestamps
     *

--- a/src/main/scala/ai/starlake/job/transform/AutoTask.scala
+++ b/src/main/scala/ai/starlake/job/transform/AutoTask.scala
@@ -210,6 +210,52 @@ abstract class AutoTask(
 
   def tableExists: Boolean
 
+  /** Column names the task's SELECT resolves to, captured by buildAllSQLQueries. Used to diagnose
+    * failed runs caused by the SELECT returning columns the target table does not have.
+    */
+  protected var resolvedSelectColumns: List[String] = Nil
+
+  /** When a run failed because the SELECT returns columns the target table does not have, wrap the
+    * raw engine error with the exact commands that fix it. Returns the original error untouched in
+    * every other case; never throws.
+    *
+    * @param targetColumns
+    *   the target table's actual column names, fetched lazily and engine-specifically by the caller
+    */
+  protected def enrichWithSchemaSyncHint(
+    targetColumns: => List[String],
+    cause: Throwable
+  ): Throwable = {
+    val hinted = Try {
+      if (resolvedSelectColumns.isEmpty || resolvedSelectColumns == List("*")) None
+      else {
+        val target = targetColumns.map(_.toLowerCase)
+        val missing =
+          if (target.isEmpty) Nil
+          else resolvedSelectColumns.filterNot(c => target.contains(c.toLowerCase))
+        if (missing.isEmpty) None
+        else {
+          val taskName = taskDesc.fullName()
+          Some(
+            new StarlakeException(
+              s"""Transform '$taskName' failed: the SELECT returns column(s) ${missing
+                  .mkString("'", "', '", "'")} that table $fullTableName does not have.
+                 |To add the missing column(s) to the table, sync the task attributes from your SQL, then re-run the transform:
+                 |  starlake transform --name $taskName --sync-apply
+                 |  starlake transform --name $taskName
+                 |Alternatively, declare the new column(s) in the attributes section of the task's .sl.yml.
+                 |Underlying error: ${Option(cause.getMessage).getOrElse(
+                  cause.toString
+                )}""".stripMargin,
+              cause
+            )
+          )
+        }
+      }
+    }.toOption.flatten
+    hinted.getOrElse(cause)
+  }
+
   protected lazy val allVars =
     schemaHandler.activeEnvVars() ++ commandParameters // ++ Map("merge" -> tableExists)
 
@@ -368,6 +414,7 @@ abstract class AutoTask(
           } else {
             extractedColumnNames
           }
+        this.resolvedSelectColumns = resolvedColumnNames
         val tableComponents = TransformStrategiesBuilder.TableComponents(
           taskDesc.database.getOrElse(""), // Convert it to "" for jinjava to work
           taskDesc.domain,

--- a/src/main/scala/ai/starlake/job/transform/BigQueryAutoTask.scala
+++ b/src/main/scala/ai/starlake/job/transform/BigQueryAutoTask.scala
@@ -156,6 +156,19 @@ class BigQueryAutoTask(
       )
     }
 
+  /** The target table's actual column names, or Nil when the table cannot be described. Used only
+    * to enrich error messages; never throws.
+    */
+  private def bqTargetColumns(): List[String] =
+    Try {
+      bqNativeJob(bigQuerySinkConfig, "ignore sql", Some(settings.appConfig.shortJobTimeoutMs))
+        .getBQSchema(targetTableId)
+        .getFields
+        .asScala
+        .map(_.getName)
+        .toList
+    }.getOrElse(Nil)
+
   override def tableExists: Boolean = {
     val tableExists =
       bqNativeJob(bigQuerySinkConfig, "ignore sql", Some(settings.appConfig.shortJobTimeoutMs))
@@ -549,8 +562,9 @@ class BigQueryAutoTask(
               jobResult
             case Failure(err) =>
               val end = Timestamp.from(Instant.now())
-              logAuditFailure(start, end, err, test)
-              Failure(err)
+              val enriched = enrichWithSchemaSyncHint(bqTargetColumns(), err)
+              logAuditFailure(start, end, enriched, test)
+              Failure(enriched)
           }
 
         case Some(_) =>

--- a/src/main/scala/ai/starlake/job/transform/JdbcAutoTask.scala
+++ b/src/main/scala/ai/starlake/job/transform/JdbcAutoTask.scala
@@ -189,6 +189,18 @@ class JdbcAutoTask(
     * @param sqlConnection
     *   Optional existing connection to reuse
     */
+  /** The target table's actual column names, or Nil when the table cannot be described (absent
+    * table, closed connection, ...). Used only to enrich error messages; never throws.
+    */
+  private def jdbcTargetColumns(conn: java.sql.Connection): List[String] =
+    Try {
+      val stmt = conn.prepareStatement(s"SELECT * FROM $fullTableName WHERE 1=0")
+      try {
+        val metaData = stmt.executeQuery().getMetaData
+        (1 to metaData.getColumnCount).map(metaData.getColumnName).toList
+      } finally stmt.close()
+    }.getOrElse(Nil)
+
   def runJDBC(
     df: Option[DataFrame],
     sqlConnection: Option[java.sql.Connection] = None
@@ -330,7 +342,7 @@ class JdbcAutoTask(
                     conn.commit()
                   case Failure(e) =>
                     conn.rollback()
-                    throw e
+                    throw enrichWithSchemaSyncHint(jdbcTargetColumns(conn), e)
                 }
               }
           }

--- a/src/test/scala/ai/starlake/job/transform/DuckDbOverwriteSchemaSpec.scala
+++ b/src/test/scala/ai/starlake/job/transform/DuckDbOverwriteSchemaSpec.scala
@@ -71,7 +71,10 @@ class DuckDbOverwriteSchemaSpec extends TestHelper {
       }
     }
 
-    private def runOverwrite(sql: String): Unit = {
+    private def runOverwrite(
+      sql: String,
+      attributes: List[TableAttribute] = Nil
+    ): scala.util.Try[String] = {
       val businessTask = AutoTaskInfo(
         name = "",
         sql = Some(sql),
@@ -80,7 +83,8 @@ class DuckDbOverwriteSchemaSpec extends TestHelper {
         table = "mytable",
         sink = Some(JdbcSink(connectionRef = Some("test-duckdb")).toAllSinks()),
         python = None,
-        writeStrategy = Some(WriteStrategy(`type` = Some(WriteStrategyType.OVERWRITE)))
+        writeStrategy = Some(WriteStrategy(`type` = Some(WriteStrategyType.OVERWRITE))),
+        attributes = attributes
       )
       val businessTaskDef = mapper
         .writer()
@@ -95,24 +99,87 @@ class DuckDbOverwriteSchemaSpec extends TestHelper {
     }
 
     "OVERWRITE into an existing table with reordered SELECT columns" should
-      "write every value into the column of the same name" in {
-        setupInitialData()
+    "write every value into the column of the same name" in {
+      setupInitialData()
 
-        // The SELECT emits the same columns as the target but in a different
-        // order (name first, id second; both VARCHAR, so arity and types line
-        // up positionally). A positional INSERT would succeed and silently
-        // write names into id and ids into name.
-        runOverwrite(
-          """SELECT * FROM (VALUES
+      // The SELECT emits the same columns as the target but in a different
+      // order (name first, id second; both VARCHAR, so arity and types line
+      // up positionally). A positional INSERT would succeed and silently
+      // write names into id and ids into name.
+      runOverwrite(
+        """SELECT * FROM (VALUES
             |  ('Xavier', '10', 1000),
             |  ('Yolanda', '20', 2000)
             |) AS t(name, id, amount)""".stripMargin
-        )
+      )
 
-        val results = readTable()
-        results should have size 2
-        results should contain(("10", "Xavier", 1000))
-        results should contain(("20", "Yolanda", 2000))
+      val results = readTable()
+      results should have size 2
+      results should contain(("10", "Xavier", 1000))
+      results should contain(("20", "Yolanda", 2000))
+    }
+
+    "OVERWRITE with a column the table does not have and no declared attributes" should
+    "fail loudly and leave the existing data untouched" in {
+      setupInitialData()
+
+      val result = runOverwrite(
+        """SELECT * FROM (VALUES
+            |  ('10', 'Xavier', 1000, 'x@x.com'),
+            |  ('20', 'Yolanda', 2000, 'y@y.com')
+            |) AS t(id, name, amount, email)""".stripMargin
+      )
+
+      result.isFailure shouldBe true
+      // the pre-existing rows must survive the failed run: TRUNCATE and the
+      // failed INSERT share a transaction and roll back together
+      val results = readTable()
+      results should have size 2
+      results should contain(("1", "Alice", 100))
+      results should contain(("2", "Bob", 200))
+    }
+
+    "OVERWRITE with a new mid-SELECT column and declared typed attributes" should
+    "sync the schema and land every value in the column of the same name" in {
+      setupInitialData()
+
+      // email is added in the MIDDLE of the SELECT. The schema sync appends
+      // it at the END of the table; only a name-based INSERT can line the
+      // two up.
+      val result = runOverwrite(
+        """SELECT * FROM (VALUES
+            |  ('10', 'x@x.com', 'Xavier', 1000),
+            |  ('20', 'y@y.com', 'Yolanda', 2000)
+            |) AS t(id, email, name, amount)""".stripMargin,
+        attributes = List(
+          TableAttribute(name = "id", `type` = "string"),
+          TableAttribute(name = "email", `type` = "string"),
+          TableAttribute(name = "name", `type` = "string"),
+          TableAttribute(name = "amount", `type` = "int")
+        )
+      )
+      result.isSuccess shouldBe true
+
+      val results = withDuckDbConnection { conn =>
+        val rs = conn
+          .createStatement()
+          .executeQuery("SELECT id, name, amount, email FROM mydb.mytable ORDER BY id")
+        val buf = scala.collection.mutable.ListBuffer[(String, String, Int, String)]()
+        while (rs.next()) {
+          buf += (
+            (
+              rs.getString("id"),
+              rs.getString("name"),
+              rs.getInt("amount"),
+              rs.getString("email")
+            )
+          )
+        }
+        buf.toList
       }
+      results should have size 2
+      results should contain(("10", "Xavier", 1000, "x@x.com"))
+      results should contain(("20", "Yolanda", 2000, "y@y.com"))
+    }
   }
 }

--- a/src/test/scala/ai/starlake/job/transform/DuckDbOverwriteSchemaSpec.scala
+++ b/src/test/scala/ai/starlake/job/transform/DuckDbOverwriteSchemaSpec.scala
@@ -1,0 +1,118 @@
+package ai.starlake.job.transform
+
+import ai.starlake.TestHelper
+import ai.starlake.config.Settings
+import ai.starlake.extract.JdbcDbUtils
+import ai.starlake.schema.model._
+import ai.starlake.workflow.IngestionWorkflow
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.hadoop.fs.Path
+
+class DuckDbOverwriteSchemaSpec extends TestHelper {
+
+  lazy val duckDbPath = s"$starlakeTestRoot/test_overwrite_schema.db"
+  lazy val pathBusiness = new Path(starlakeMetadataPath + "/transform/mydb/mytable.sl.yml")
+  lazy val pathSqlBusiness = new Path(starlakeMetadataPath + "/transform/mydb/mytable.sql")
+
+  lazy val duckDbConfiguration: Config = {
+    val config = ConfigFactory.parseString(
+      s"""
+         |connectionRef: "test-duckdb"
+         |connections.test-duckdb {
+         |    type = "jdbc"
+         |    options {
+         |      "url": "jdbc:duckdb:$duckDbPath"
+         |      "driver": "org.duckdb.DuckDBDriver"
+         |    }
+         |}
+         |""".stripMargin
+    )
+    config.withFallback(super.testConfiguration)
+  }
+
+  new WithSettings(duckDbConfiguration) {
+
+    private def withDuckDbConnection[T](f: java.sql.Connection => T): T = {
+      val connection = "test-duckdb"
+      val options = settings.appConfig.connections(connection).options
+      JdbcDbUtils.withJDBCConnection(settings.schemaHandler().dataBranch(), options) { conn =>
+        f(conn)
+      }
+    }
+
+    private def setupInitialData(): Unit = {
+      withDuckDbConnection { conn =>
+        val stmt = conn.createStatement()
+        stmt.execute("CREATE SCHEMA IF NOT EXISTS mydb")
+        stmt.execute("DROP TABLE IF EXISTS mydb.mytable")
+        stmt.execute(
+          """CREATE TABLE mydb.mytable(
+            |  id VARCHAR,
+            |  name VARCHAR,
+            |  amount INTEGER
+            |)""".stripMargin
+        )
+        stmt.execute(
+          "INSERT INTO mydb.mytable VALUES ('1', 'Alice', 100), ('2', 'Bob', 200)"
+        )
+      }
+    }
+
+    private def readTable(): Seq[(String, String, Int)] = {
+      withDuckDbConnection { conn =>
+        val rs = conn
+          .createStatement()
+          .executeQuery("SELECT id, name, amount FROM mydb.mytable ORDER BY id")
+        val buf = scala.collection.mutable.ListBuffer[(String, String, Int)]()
+        while (rs.next()) {
+          buf += ((rs.getString("id"), rs.getString("name"), rs.getInt("amount")))
+        }
+        buf.toList
+      }
+    }
+
+    private def runOverwrite(sql: String): Unit = {
+      val businessTask = AutoTaskInfo(
+        name = "",
+        sql = Some(sql),
+        database = None,
+        domain = "mydb",
+        table = "mytable",
+        sink = Some(JdbcSink(connectionRef = Some("test-duckdb")).toAllSinks()),
+        python = None,
+        writeStrategy = Some(WriteStrategy(`type` = Some(WriteStrategyType.OVERWRITE)))
+      )
+      val businessTaskDef = mapper
+        .writer()
+        .withAttribute(classOf[Settings], settings)
+        .writeValueAsString(businessTask)
+      storageHandler.write(businessTaskDef, pathBusiness)
+      storageHandler.write(businessTask.getSql(), pathSqlBusiness)
+
+      val schemaHandler = settings.schemaHandler()
+      val workflow = new IngestionWorkflow(storageHandler, schemaHandler)
+      workflow.autoJob(TransformConfig(name = "mydb.mytable"))
+    }
+
+    "OVERWRITE into an existing table with reordered SELECT columns" should
+      "write every value into the column of the same name" in {
+        setupInitialData()
+
+        // The SELECT emits the same columns as the target but in a different
+        // order (name first, id second; both VARCHAR, so arity and types line
+        // up positionally). A positional INSERT would succeed and silently
+        // write names into id and ids into name.
+        runOverwrite(
+          """SELECT * FROM (VALUES
+            |  ('Xavier', '10', 1000),
+            |  ('Yolanda', '20', 2000)
+            |) AS t(name, id, amount)""".stripMargin
+        )
+
+        val results = readTable()
+        results should have size 2
+        results should contain(("10", "Xavier", 1000))
+        results should contain(("20", "Yolanda", 2000))
+      }
+  }
+}

--- a/src/test/scala/ai/starlake/job/transform/DuckDbOverwriteSchemaSpec.scala
+++ b/src/test/scala/ai/starlake/job/transform/DuckDbOverwriteSchemaSpec.scala
@@ -131,6 +131,11 @@ class DuckDbOverwriteSchemaSpec extends TestHelper {
       )
 
       result.isFailure shouldBe true
+      // the error must name the offending column and tell the user exactly
+      // how to evolve the table schema
+      val message = result.failed.get.getMessage
+      message should include("email")
+      message should include("starlake transform --name mydb.mytable --sync-apply")
       // the pre-existing rows must survive the failed run: TRUNCATE and the
       // failed INSERT share a transaction and roll back together
       val results = readTable()

--- a/src/test/scala/ai/starlake/job/transform/DuckDbSyncSqlWithYamlSpec.scala
+++ b/src/test/scala/ai/starlake/job/transform/DuckDbSyncSqlWithYamlSpec.scala
@@ -1,0 +1,125 @@
+package ai.starlake.job.transform
+
+import ai.starlake.TestHelper
+import ai.starlake.config.Settings
+import ai.starlake.extract.JdbcDbUtils
+import ai.starlake.schema.model._
+import ai.starlake.workflow.IngestionWorkflow
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.hadoop.fs.Path
+
+class DuckDbSyncSqlWithYamlSpec extends TestHelper {
+
+  lazy val duckDbPath = s"$starlakeTestRoot/test_sync_sql_yaml.db"
+  lazy val pathBusiness = new Path(starlakeMetadataPath + "/transform/mydb/mytable.sl.yml")
+  lazy val pathSqlBusiness = new Path(starlakeMetadataPath + "/transform/mydb/mytable.sql")
+
+  lazy val duckDbConfiguration: Config = {
+    val config = ConfigFactory.parseString(
+      s"""
+         |connectionRef: "test-duckdb"
+         |syncSqlWithYaml = true
+         |connections.test-duckdb {
+         |    type = "jdbc"
+         |    options {
+         |      "url": "jdbc:duckdb:$duckDbPath"
+         |      "driver": "org.duckdb.DuckDBDriver"
+         |    }
+         |}
+         |""".stripMargin
+    )
+    config.withFallback(super.testConfiguration)
+  }
+
+  new WithSettings(duckDbConfiguration) {
+
+    private def withDuckDbConnection[T](f: java.sql.Connection => T): T = {
+      val connection = "test-duckdb"
+      val options = settings.appConfig.connections(connection).options
+      JdbcDbUtils.withJDBCConnection(settings.schemaHandler().dataBranch(), options) { conn =>
+        f(conn)
+      }
+    }
+
+    private def setupInitialData(): Unit = {
+      withDuckDbConnection { conn =>
+        val stmt = conn.createStatement()
+        stmt.execute("CREATE SCHEMA IF NOT EXISTS mydb")
+        stmt.execute("DROP TABLE IF EXISTS mydb.mytable")
+        stmt.execute(
+          """CREATE TABLE mydb.mytable(
+            |  id VARCHAR,
+            |  name VARCHAR,
+            |  amount INTEGER
+            |)""".stripMargin
+        )
+        stmt.execute(
+          "INSERT INTO mydb.mytable VALUES ('1', 'Alice', 100), ('2', 'Bob', 200)"
+        )
+      }
+    }
+
+    private def runOverwrite(sql: String): scala.util.Try[String] = {
+      // SQL-only task: no attributes declared, exactly like a hand-written
+      // transform whose .sl.yml carries only the write strategy
+      val businessTask = AutoTaskInfo(
+        name = "",
+        sql = Some(sql),
+        database = None,
+        domain = "mydb",
+        table = "mytable",
+        sink = Some(JdbcSink(connectionRef = Some("test-duckdb")).toAllSinks()),
+        python = None,
+        writeStrategy = Some(WriteStrategy(`type` = Some(WriteStrategyType.OVERWRITE)))
+      )
+      val businessTaskDef = mapper
+        .writer()
+        .withAttribute(classOf[Settings], settings)
+        .writeValueAsString(businessTask)
+      storageHandler.write(businessTaskDef, pathBusiness)
+      storageHandler.write(businessTask.getSql(), pathSqlBusiness)
+
+      val schemaHandler = settings.schemaHandler()
+      val workflow = new IngestionWorkflow(storageHandler, schemaHandler)
+      workflow.autoJob(TransformConfig(name = "mydb.mytable"))
+    }
+
+    "OVERWRITE with a new mid-SELECT column, no declared attributes, syncSqlWithYaml on" should
+    "sync the YAML from the SQL, evolve the table, and land values by name" in {
+      setupInitialData()
+
+      val result = runOverwrite(
+        """SELECT * FROM (VALUES
+          |  ('10', 'x@x.com', 'Xavier', 1000),
+          |  ('20', 'y@y.com', 'Yolanda', 2000)
+          |) AS t(id, email, name, amount)""".stripMargin
+      )
+      result.isSuccess shouldBe true
+
+      val results = withDuckDbConnection { conn =>
+        val rs = conn
+          .createStatement()
+          .executeQuery("SELECT id, name, amount, email FROM mydb.mytable ORDER BY id")
+        val buf = scala.collection.mutable.ListBuffer[(String, String, Int, String)]()
+        while (rs.next()) {
+          buf += (
+            (
+              rs.getString("id"),
+              rs.getString("name"),
+              rs.getInt("amount"),
+              rs.getString("email")
+            )
+          )
+        }
+        buf.toList
+      }
+      results should have size 2
+      results should contain(("10", "Xavier", 1000, "x@x.com"))
+      results should contain(("20", "Yolanda", 2000, "y@y.com"))
+
+      // the sync must have written the resolved attributes back to the YAML
+      val yaml = storageHandler.read(pathBusiness)
+      yaml should include("email")
+    }
+  }
+}


### PR DESCRIPTION
Backport of #1723 (fixes #1722) onto branch-1.8, newly created from tag v1.8.1 for the 1.8.x maintenance line.

All five commits cherry-picked clean, no conflicts. Verified on this branch: DuckDbOverwriteSchemaSpec, DuckDbSyncSqlWithYamlSpec, DuckDbMergeStrategySpec - 8 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWLuy2yBXT6ynzrrzapdjr