### PR TITLE
bootstrap: give every assistant the project it is actually in

### DIFF
--- a/src/main/resources/templates/bootstrap/samples/empty-project/AGENTS.md
+++ b/src/main/resources/templates/bootstrap/samples/empty-project/AGENTS.md
@@ -1,0 +1,223 @@
+# AGENTS.md — how to work in this Starlake project
+
+You are assisting inside a **Starlake / Starflow** data pipeline project created
+from the `empty-project` template. This file is the contract for how you work
+here. It describes **method**: what it says about the project's *contents* is
+true of the template as shipped and stops being true the moment someone adds
+something, so the filesystem is always the authority.
+
+---
+
+## What this project is
+
+A `metadata/` skeleton and nothing else: **no domains, no tables, no transforms,
+no tests**. Each of those exists only once someone has created it. At any moment
+the project contains exactly what is on disk.
+
+What the template does ship:
+
+- `metadata/application.sl.yml` — connections (DuckDB, BigQuery, Snowflake,
+  PostgreSQL, Redshift), the audit sink, DAG references and schedule presets
+- `metadata/env.sl.yml` — the default environment (`activeConnection: duckdb`);
+  override it with `metadata/env.<NAME>.sl.yml` and `SL_ENV=<NAME>`
+- `metadata/types/` — the built-in types with their DDL mapping per engine
+- `metadata/expectations/` — the Jinja2 data-quality macros this project ships
+- `metadata/dags/` — DAG configuration templates for Airflow, Dagster and
+  Snowflake native
+- `metadata/starlake.json` — the JSON Schema for every `.sl.yml`
+
+The engine is **DuckDB** by default; both the tables you load and the `audit.*`
+tables land in `datasets/duckdb.db`.
+
+Starting points, once you know what the project should contain:
+
+```bash
+starlake infer-schema --domain <domain> --table <table> --input <file> --outputDir metadata/load
+starlake autoload            # infer AND load everything under datasets/incoming/<domain>/
+starlake validate
+```
+
+---
+## Ground rules
+
+**1 — Never assume. Read the project first.**
+Do not answer a question about this project from a template, from a sample you
+have seen elsewhere, or from an earlier turn in the conversation. List the
+directory, open the file, run the command. A name that looks familiar because
+another Starlake project uses it is a reason to check, not a reason to trust.
+
+**2 — Never invent syntax.** YAML keys, CLI flags, expectation macro names and
+write strategies either exist in this project's authorities or they do not
+exist. YAML keys → `metadata/starlake.json`, the JSON Schema for every `.sl.yml`.
+Expectation macros → `ls metadata/expectations/`, and that listing is the whole
+list. CLI flags → `starlake <command> --help`. A key you half-remember from
+documentation is not evidence: if you cannot point to where a name comes from,
+do not write it.
+
+**3 — Cite where each answer came from.** For every non-trivial claim, name the
+file you read or the command you ran. "According to `metadata/load/x/y.sl.yml`"
+is an answer; "typically, Starlake uses…" is a guess wearing an answer's clothes.
+
+**4 — Run the gate. Do not predict it.** After any change to `metadata/`, run
+`starlake validate` — and `starlake test` / `starlake dag-generate` when they
+apply — and report the real output. Never write "this should validate".
+
+**5 — Change only what was asked.** One table, one task, one file. Do not
+reformat, reorder attributes, "fix" neighbouring files, or delete comments you
+did not write. Attribute order is part of a table's contract.
+
+**6 — "I checked, and it is not there" is a correct answer.** So is "I don't
+know". A plausible answer that turns out to be invented costs more than a
+question.
+
+---
+
+## Before you answer — look here first
+
+| The question is about… | Read or run this before answering |
+|---|---|
+| which domains / tables exist | `ls metadata/load/` then `ls metadata/load/<domain>/` |
+| a table's columns, types, write strategy | `metadata/load/<domain>/<table>.sl.yml` |
+| which transforms exist | `ls metadata/transform/` and its `*.sl.yml` + `*.sql` pairs |
+| which expectation macros are available | `ls metadata/expectations/` — these `.j2` files are the whole list |
+| which types are available | `metadata/types/types.sl.yml` and `default.sl.yml` |
+| which connection / engine is active | `metadata/env.sl.yml`, then `starlake settings` |
+| what a load or transform actually did | the `audit.audit` table |
+| why a row was rejected | the `audit.rejected` table |
+| whether a declared rule passed | the `audit.expectations` table |
+| what feeds what | `starlake lineage`, `starlake col-lineage`, `starlake table-dependencies` |
+| which DAG templates ship here | `ls metadata/dags/` |
+| any `.sl.yml` key you are unsure of | `metadata/starlake.json` |
+| any CLI flag you are unsure of | `starlake <command> --help` |
+
+---
+
+## The authorities, in order
+
+When they disagree, the earlier one wins.
+
+1. **This project's files** — `metadata/**`, `metadata/starlake.json`,
+   `metadata/expectations/*.j2`, `metadata/types/*.sl.yml`.
+2. **`starlake <command> --help`** — the flags this CLI version actually accepts.
+3. **The installed Starlake skills** — one per CLI command, plus configuration
+   and best-practice skills. Consult the skill for a command *before* writing
+   that command.
+4. **Nothing else.** Not your memory of the documentation, not a blog post, not
+   another Starlake project.
+
+---
+
+## The gate
+
+```bash
+starlake validate                                  # the YAML is well-formed and coherent
+starlake test                                      # the unit tests, when the project has any
+starlake dag-generate --clean --outputDir out/dags # the orchestration still generates
+```
+
+Two things about this CLI you must not misread:
+
+- **It is silent on success.** Exit code 0 with empty stdout means it worked, not
+  that it did nothing. Prefix a command with `SL_LOG_LEVEL=info` to see the SQL it
+  ran, the write strategy it applied and the audit rows it inserted.
+- **`validate` judges the YAML, not the result.** A configuration can validate
+  perfectly and still load the wrong rows. Only the data and the `audit.*` tables
+  tell you what happened.
+
+Before running any `starlake` command, check the CLI is on the PATH with
+`starlake --version`; if it is not, ask for its path rather than guessing one. On
+Windows the command is `starlake.cmd`.
+
+---
+
+## Reading what actually happened
+
+The audit tables live in the same warehouse as the data.
+
+| Table | Answers |
+|---|---|
+| `audit.audit` | what ran: domain, table, step (`LOAD` / `TRANSFORM`), counts, success |
+| `audit.rejected` | which rule stopped a row, and which file it came from |
+| `audit.expectations` | which declared data-quality rule passed or failed, and its count |
+
+Never describe what one of these tables holds from memory — read its columns
+first. An audit table that does not store what you are about to hand back is a
+trap you can only avoid by looking:
+
+```bash
+starlake transform --name __ignore__.__ignore__ --query "describe audit.rejected" --interactive csv
+```
+
+`__ignore__.__ignore__` is the CLI's sentinel for "no task, just run this SQL";
+any other name must resolve to a task that exists.
+
+---
+
+## The skills are your manual
+
+A Starlake skill is installed for every CLI command and for the main
+configuration topics. They are the reference for syntax and options — read the
+relevant one instead of recalling it.
+
+- Claude Code: `~/.claude/skills/`
+- Gemini CLI: `~/.gemini/skills/`
+- GitHub Copilot: `~/.copilot/skills/`
+
+**The directory listing is the authoritative catalogue** — run `ls` on it rather
+than trusting the list below, which names only the ones a project like this one
+uses most:
+
+- **Project & config** — `config`, `connection`, `settings`, `validate`,
+  `bootstrap`, `migrate`, `console`, `serve`
+- **Schema discovery** — `infer-schema`, `autoload`, `preload`, `extract-schema`,
+  `extract-data`, `extract-bq-schema`, `extract-rest-schema`, `extract-rest-data`
+- **Loading** — `stage`, `load`, `ingest`, `cnxload`, `esload`, `kafkaload`
+- **Data quality** — `expectations`, `test`, `metrics`, `summarize`, `freshness`
+- **Transforms & lineage** — `transform`, `lineage`, `col-lineage`,
+  `table-dependencies`, `acl-dependencies`
+- **Semantic & catalog** — `semantic`, `semantic-export`, `site`, `secure`,
+  `iam-policies`
+- **Orchestration** — `dag-generate`, `dag-create`, `dag-template-generate`,
+  `dag-deploy`
+
+**Starflow** adds a guided methodology on top: expert personas
+(`starflow-data-architect`, `starflow-data-engineer`,
+`starflow-data-quality-engineer`, `starflow-data-analyst`,
+`starflow-platform-engineer`) and workflow skills
+(`starflow-create-pipeline-spec`, `starflow-dev-pipeline`,
+`starflow-schema-design`, `starflow-transform-design`,
+`starflow-semantic-model-design`, `starflow-orchestration-design`,
+`starflow-code-review`, `starflow-data-quality-review`,
+`starflow-lineage-review`, `starflow-help`).
+
+They are installed from [starlake-ai/starlake-skills](https://github.com/starlake-ai/starlake-skills);
+if the directory is empty, say so rather than guessing a command's options.
+
+---
+
+## Configuration conventions
+
+- All metadata files use the `.sl.yml` extension and start with `version: 1`
+- Variables use `{{VAR_NAME}}` Mustache-style templating, resolved from the env
+  files or the shell environment
+- Load tables define `pattern`, `metadata.format` (DSV / JSON / JSON_FLAT…) and a
+  `writeStrategy`
+- Transform tasks pair a `.sl.yml` (columns, domain, write strategy) with a `.sql`
+  file holding the query
+- Data-quality expectations in `metadata/expectations/` are Jinja2 macros invoked
+  as `{{ macro_name(table, column, ...) }}`
+- `metadata/starlake.json` is the JSON Schema for every `.sl.yml`, which is what
+  gives an editor its validation and completion
+
+---
+
+## How to hand back a change
+
+1. Say what you read to decide (files, commands).
+2. Show the diff, minimal, one concern at a time.
+3. Run the gate and paste its **real** output.
+4. State plainly what you did not verify, and what you would check next.
+
+If a request is ambiguous — two tables could be meant, two write strategies would
+both work — ask, or state the assumption in one line and proceed. Do not silently
+pick one and present it as the only reading.

--- a/src/main/resources/templates/bootstrap/samples/empty-project/GEMINI.md
+++ b/src/main/resources/templates/bootstrap/samples/empty-project/GEMINI.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# GEMINI.md
 
-Guidance for Claude Code working in this **Starlake / Starflow** project.
+Guidance for Gemini working in this **Starlake / Starflow** project.
 
 The full contract is in [AGENTS.md](AGENTS.md) — what this project contains, where
 to look things up, and how to hand back a change. Read it before your first edit.

--- a/src/main/resources/templates/bootstrap/samples/empty-project/README.md
+++ b/src/main/resources/templates/bootstrap/samples/empty-project/README.md
@@ -1,206 +1,54 @@
-## StarBake
+# A new Starlake project
 
-**StarBake** is a fictional & demonstrative project designed to showcase the usage of Starlake Starflow for data transformation and analytics in an e-commerce bakery business setting. The project begins by collecting raw operational data from various domains, including digital transactions, customer interactions, inventory management, and supplier relationships.
+This project was created from the `empty-project` template. It holds a
+`metadata/` skeleton and no data model yet: **no domains, no tables, no
+transforms, no tests** — you add those.
 
-This data is organized into six primary tables: Customers, Orders, Products, Suppliers, Ingredients, and ProductIngredients. Each table contains relevant data fields that are updated daily, with data arriving in JSON, JsonND, or CSV format.
+## What is already here
 
-The core of the StarBake project lies in its transformation of the ingested raw data. The data is converted into meaningful business insights by creating a series of analytical-ready tables: CustomerLifetimeValue, ProductPerformance, ProductProfitability, HighValueCustomers, TopSellingProducts, and MostProfitableProducts. Further tables (TopSellingProfitableProducts and HighValueCustomerPreferences) are created by joining multiple transformed tables to deliver more nuanced business insights.
+| Path | What it is |
+| --- | --- |
+| `metadata/application.sl.yml` | connections (DuckDB, BigQuery, Snowflake, PostgreSQL, Redshift), the audit sink, DAG references, schedule presets |
+| `metadata/env.sl.yml` | the default environment — `activeConnection: duckdb`. Add `metadata/env.<NAME>.sl.yml` and select it with `SL_ENV=<NAME>` |
+| `metadata/types/` | the built-in types and their DDL mapping per engine |
+| `metadata/expectations/` | the Jinja2 data-quality macros you can call from a table's `expectations:` |
+| `metadata/dags/` | DAG configuration templates for Airflow, Dagster and Snowflake native |
+| `metadata/starlake.json` | the JSON Schema behind every `.sl.yml` — this is what gives your editor validation and completion |
+| `datasets/` | where the DuckDB database and your incoming files live |
 
-The final goal of StarBake is to provide users a practical understanding of how Starflow can be harnessed for data ingestion, transformation, and analytics. The project focuses on Google BigQuery as the data warehousing solution. Through this project, users will get hands-on experience in gleaning a wide range of business insights, including customer lifetime value, product performance, product profitability, and customer preferences.
+The default engine is **DuckDB**, so the project runs with no cloud account and
+no configuration: both your tables and the `audit.*` tables land in
+`datasets/duckdb.db`.
 
+## Getting started
 
-### Tables to Ingest:
+```bash
+export SL_ROOT=$PWD          # the variable that tells the CLI which project to act on
+starlake validate            # should report no errors
 
-Here's a breakdown of the tables with column descriptions:
+# describe a source file as a table, then load it
+starlake infer-schema --domain <domain> --table <table> \
+         --input <path/to/file.csv> --outputDir metadata/load
+starlake load --domains <domain> --tables <table> --files <path/to/file.csv>
 
-1. **Customers:** This table contains information about the bakery's customers. The data for this table arrives in CSV format, updated daily with deltas.
-    - `customer_id` (PK): A unique identifier for each customer. Data type: Integer or UUID.
-    - `first_name`: The customer's first name. Data type: String.
-    - `last_name`: The customer's last name. Data type: String.
-    - `email`: The customer's email address. Data type: String.
-    - `join_date`: The date when the customer joined. Data type: Date.
-
-2. **Orders:** This table contains information about the bakery's orders. The data for this table arrives in JSON format, updated daily with deltas.
-    - `order_id` (PK): A unique identifier for each order. Data type: Integer or UUID.
-    - `customer_id` (FK): An identifier for the customer who placed the order. Data type: Integer or UUID, referencing `Customers.customer_id`.
-    - `timestamp`: The date and time when the order was placed. Data type: DateTime.
-    - `status`: The status of the order, such as 'placed', 'shipped', or 'delivered'. Data type: String.
-    - `products`: An array of objects, each containing `product_id`, `quantity`, and `price`. Each object represents a product in the order.
-        - `product_id`: An identifier for the product. Data type: Integer or UUID, referencing `Products.product_id`.
-        - `quantity`: The quantity of this product in the order. Data type: Integer.
-        - `price`: The price of the product at the time of ordering. Data type: Decimal.
-
-3. **Products:** This table contains information about the bakery's products. The data for this table arrives in JSON_ND format, updated daily with deltas.
-    - `product_id` (PK): A unique identifier for each product. Data type: Integer or UUID.
-    - `name`: The product's name. Data type: String. 
-    - `details`: A record containing additional details about the product.
-        - `price`: The current[orders.yaml](domains%2Forders.yaml) price of the product. Data type: Decimal.
-        - `description`: A detailed description of the product. Data type: String.
-        - `category`: The category of the product, such as 'bread', 'cake', or 'pastry'. Data type: String.
-    - `ingredients`: An array of objects, each containing `ingredient_id` and `quantity`. Each object represents an ingredient needed to make the product.
-        - `ingredient_id`: An identifier for the ingredient. Data type: Integer or UUID, referencing `Ingredients.ingredient_id`.
-        - `quantity`: The quantity of this ingredient needed to make the product. Data type: Decimal.
-
-4. **Ingredients:** This table contains information about the bakery's ingredients. The data for this table arrives in TSV format, updated daily with deltas.
-    - `ingredient_id` (PK): A unique identifier for each ingredient. Data type: Integer or UUID.
-    - `name`: The ingredient's name. Data type: String.
-    - `price`: The current price of the ingredient. Data type: Decimal.
-    - `quantity_in_stock`: The quantity of the ingredient currently in stock. Data type: Decimal.
-
-The data type mentioned in each field is a common standard, but the exact type can change depending on the database you are using. JSON objects and arrays are usually represented as strings in a database but parsed into their respective data structures when needed.
-
-
-```mermaid
-erDiagram
-    CUSTOMERS ||--o{ ORDERS : places
-    PRODUCTS ||--o{ ORDERS : "is ordered in"
-    PRODUCTS ||--o{ INGREDIENTS : "is made of"
-
-    CUSTOMERS {
-        int customer_id PK
-        string first_name
-        string last_name
-        string email
-        date join_date
-    }
-
-    ORDERS {
-        int order_id PK
-        int customer_id FK
-        datetime timestamp
-        string status
-        products[] products
-    }
-
-    PRODUCTS {
-        int product_id PK
-        string name
-        record details
-        ingredients[] ingredients
-    }
-
-    INGREDIENTS {
-        int ingredient_id PK
-        string name
-        decimal price
-        decimal quantity_in_stock
-    }
-
+# or let the CLI do both for everything under datasets/incoming/<domain>/
+starlake autoload
 ```
 
+The CLI is **silent on success**: exit code 0 with no output means it worked, not
+that it did nothing. Prefix any command with `SL_LOG_LEVEL=info` to see the SQL it
+ran, the write strategy it applied and the audit rows it inserted.
 
-### Business Insights transformations:
+## Working with an AI assistant
 
-1. **CustomerLifetimeValue:** This table gives a projection of the total value a customer may bring to the bakery over the entirety of their relationship. This will be calculated using data from the `Customers` & `Orders` tables, and have total spend to date, average spend per order, and frequency of orders.
+`AGENTS.md` is the contract your assistant reads: what this project contains,
+where to look each thing up, and the rules it must follow — read the project
+rather than assume it, never invent a YAML key or a macro name, run
+`starlake validate` instead of predicting it. `CLAUDE.md`, `GEMINI.md` and
+`.github/copilot-instructions.md` point at it, each in the file its own assistant
+loads. Keep them in step with the project as it grows.
 
-2. **ProductPerformance:** This table provides details on the performance of each product sold at the bakery, including the total number of units sold, total revenue generated, and average revenue per unit sold. It's derived from the `Orders` and `Products` tables.
+## Where to go next
 
-3. **ProductProfitability:** This table offers insights into the profitability of each product. It considers the cost of production (based on the `Products` table & `INGREDIENTS` table for the cost of ingredients).
-
-4. **HighValueCustomers:** This table identifies customers with the highest lifetime value, making it easier to target these customers for marketing campaigns. It's derived from the `CustomerLifetimeValue` table.
-
-5. **TopSellingProducts:** This table identifies the products that perform the best in terms of units sold and revenue. It's derived from the `ProductPerformance` table.
-
-6. **MostProfitableProducts:** This table identifies the most profitable products, allowing the bakery to focus on promoting these products to maximize profits. It's derived from the `ProductProfitability` table.
-
-Additional tables that join multiple transformed tables:
-
-7. **TopSellingProfitableProducts:** This table combines the `TopSellingProducts` and `MostProfitableProducts` tables to highlight the products that are not only top sellers but also bring in high profit margins.
-
-```mermaid
-classDiagram
-    Customers --|> CustomerLifetimeValue: uses
-    Orders --|> CustomerLifetimeValue: uses
-    Orders --|> ProductPerformance: uses
-    Products --|> ProductPerformance: uses
-    Products --|> ProductProfitability: uses
-    Ingredients --|> ProductProfitability: uses
-    CustomerLifetimeValue --|> HighValueCustomers: uses
-    ProductPerformance --|> TopSellingProducts: uses
-    ProductProfitability --|> MostProfitableProducts: uses
-    TopSellingProducts --|> TopSellingProfitableProducts: uses
-    MostProfitableProducts --|> TopSellingProfitableProducts: uses
-
-    class CustomerLifetimeValue {
-        +customer_id: integer
-        +customer_full_name: string
-        +customer_join_date: date
-        +total_spend_to_date: decimal
-        +average_spend_per_order: decimal
-        +frequency_of_orders: integer
-    }
-
-    class ProductPerformance {
-        +product_id: integer
-        +product_name: string
-        +total_units_sold: integer
-        +total_revenue: decimal
-        +average_revenue_per_unit: decimal
-    }
-
-    class ProductProfitability {
-        +product_id: integer
-        +product_name: string
-        +profit_margin_per_product: decimal
-    }
-
-    class HighValueCustomers {
-        +customer_id: integer
-        +customer_full_name: string
-        +lifetime_value: decimal
-    }
-
-    class TopSellingProducts {
-        +product_id: integer
-        +product_name: string
-        +units_sold: integer
-        +revenue: decimal
-    }
-
-    class MostProfitableProducts {
-        +product_id: integer
-        +product_name: string
-        +profit_margin: decimal
-    }
-
-    class TopSellingProfitableProducts {
-        +product_id: integer
-        +product_name: string
-        +units_sold: integer
-        +revenue: decimal
-        +profit_margin: decimal
-    }
-
-
-```
-The project aims to give users a practical understanding of Starflow's functionalities, allowing them to leverage these features for their data transformation and analytics requirements.
-
-## How to run
-Please check [HOW_TO_RUN.md](HOW_TO_RUN.md)
-
-## To-Do List
-
-#### Data Ingestion
-- [x] Set up data ingestion mechanisms for each of the primary tables.
-    - [x] Configure CSV data ingestion for the `Customers`, and `Ingredients` tables.
-    - [x] Configure JSON data ingestion for the `Orders` table.
-    - [x] Configure JsonND data ingestion for the `Products` table.
-
-#### Data Transformation
-- [x] Define transformations for creating analytical tables.
-    - [x] Design transformations for CustomerLifetimeValue
-    - [x] Design transformations for ProductPerformance
-    - [x] Design transformations for ProductProfitability
-    - [x] Design transformations for HighValueCustomers
-    - [x] Design transformations for TopSellingProducts
-    - [x] Design transformations for MostProfitableProducts
-    - [x] Design transformations for TopSellingProfitableProducts
-
-#### Data Combination
-- [x] Combine multiple transformed tables to create new analytical tables.
-    - [x] Create `TopSellingProfitableProducts` table by merging `TopSellingProducts` and `MostProfitableProducts`.
-
-#### Workflow
-- [ ] Add .vscode project configuration that include the necessary plugins.
-- [ ] Add sqlfluff as sql formatter
-- [ ] Add pre-hook to compile & format the code before commit
+- [starlake.ai](https://starlake.ai) — product site and documentation
+- `starlake --help`, and `starlake <command> --help` for any command

--- a/src/main/resources/templates/bootstrap/samples/empty-project/copilot-instructions.md
+++ b/src/main/resources/templates/bootstrap/samples/empty-project/copilot-instructions.md
@@ -1,12 +1,10 @@
-# CLAUDE.md
+# Copilot instructions
 
-Guidance for Claude Code working in this **Starlake / Starflow** project.
+Guidance for GitHub Copilot working in this **Starlake / Starflow** project.
 
-The full contract is in [AGENTS.md](AGENTS.md) — what this project contains, where
-to look things up, and how to hand back a change. Read it before your first edit.
-The rules below are the part you must never skip.
-
-@AGENTS.md
+The full contract is in `AGENTS.md` at the project root — what this project
+contains, where to look things up, and how to hand back a change. Read it before
+your first edit. The rules below are the part you must never skip.
 
 ## Ground rules
 

--- a/src/main/resources/templates/bootstrap/samples/sample-project/AGENTS.md
+++ b/src/main/resources/templates/bootstrap/samples/sample-project/AGENTS.md
@@ -1,0 +1,269 @@
+# AGENTS.md — how to work in this Starlake project
+
+You are assisting inside **StarBake**, a Starlake / Starflow sample project: a
+fictional bakery's analytics pipeline, from raw files to KPIs. This file is the
+contract for how you work here. It describes **method**, and what it says about
+the project's *contents* is true of the template as shipped — it stops being true
+the moment someone adds or renames something, so the filesystem is always the
+authority.
+
+---
+
+## What this project is
+
+Three source files are loaded into the `starbake` domain, two analytics
+transforms read from them, and one KPI transform reads from those. The engine is
+**DuckDB** by default (`metadata/env.sl.yml` → `activeConnection`); both the
+loaded tables and the `audit.*` tables land in `datasets/duckdb.db`.
+
+```text
+datasets/incoming/starbake/     →  Load (metadata/load/starbake/)
+    customers.csv                      ↓
+    orders.json                 →  starbake.customers · starbake.orders · starbake.products
+    products.json                      ↓
+                                   Transform (metadata/transform/)
+                                       ↓
+                               starbake_analytics/
+                                 ├─ customer_purchase_history
+                                 └─ order_items_analysis
+                                       ↓
+                               starbake_kpis/
+                                 └─ overall_kpis
+```
+
+**The dependency order is implied by the SQL, not declared.**
+`starbake_analytics.customer_purchase_history` and
+`starbake_analytics.order_items_analysis` read from `starbake.*`;
+`starbake_kpis.overall_kpis` reads from both of those and must run after them.
+`--recursive` executes the upstream tasks in order for you.
+
+### Layout
+
+- `metadata/application.sl.yml` — connections (DuckDB, BigQuery, Snowflake,
+  PostgreSQL, Redshift), the audit sink, DAG references and schedule presets
+- `metadata/env.sl.yml` — the default environment (`activeConnection: duckdb`);
+  override it with `metadata/env.{BQ,PG,SNOW,REDSHIFT,...}.sl.yml`
+- `metadata/load/starbake/` — the three source table schemas; each `.sl.yml`
+  declares `pattern`, `metadata.format`, `attributes` and a `writeStrategy`
+- `metadata/transform/` — the SQL transformations, each a `.sl.yml` + `.sql` pair
+- `metadata/external/` — external table definitions for reading the outputs back
+- `metadata/types/` — the types with their DDL mapping per engine
+- `metadata/expectations/` — the Jinja2 data-quality macros this project ships
+- `metadata/dags/` — DAG configuration templates (Airflow, Dagster, Snowflake)
+- `metadata/starlake.json` — the JSON Schema for every `.sl.yml`
+- `datasets/` — the sample input files and the DuckDB database
+
+### The commands this project is driven with
+
+```bash
+starlake validate                      # the YAML is well-formed and coherent
+
+# Load the sources. Name the domain, the table and the file explicitly.
+starlake load --domains starbake --tables customers --files "${SL_ROOT}/datasets/incoming/starbake/customers.csv"
+starlake load --domains starbake --tables orders   --files "${SL_ROOT}/datasets/incoming/starbake/orders.json"
+starlake load --domains starbake --tables products --files "${SL_ROOT}/datasets/incoming/starbake/products.json"
+
+starlake transform --name starbake_analytics.customer_purchase_history
+starlake transform --name starbake_analytics.order_items_analysis
+starlake transform --name starbake_kpis.overall_kpis --recursive   # runs its upstream first
+
+starlake autoload                      # infer AND load everything under datasets/incoming/
+starlake dag-generate                  # orchestration files
+starlake settings                      # print the settings / test a connection
+starlake test                          # the unit tests
+
+export SL_ENV=BQ        # BigQuery      (default: DuckDB, no SL_ENV set)
+export SL_ENV=PG        # PostgreSQL
+export SL_ENV=SNOW      # Snowflake
+export SL_ENV=REDSHIFT  # Redshift
+```
+
+The three `.sql` files are written for **DuckDB**. Some of their lines are
+commented out rather than deleted — an alternative spelling of the same
+expression (`LIST` beside `ARRAY_AGG`), or a column left disabled. They are notes,
+not dead code to restore blindly, and none of them is an engine-specific variant.
+
+---
+## Ground rules
+
+**1 — Never assume. Read the project first.**
+Do not answer a question about this project from a template, from a sample you
+have seen elsewhere, or from an earlier turn in the conversation. List the
+directory, open the file, run the command. A name that looks familiar because
+another Starlake project uses it is a reason to check, not a reason to trust.
+
+**2 — Never invent syntax.** YAML keys, CLI flags, expectation macro names and
+write strategies either exist in this project's authorities or they do not
+exist. YAML keys → `metadata/starlake.json`, the JSON Schema for every `.sl.yml`.
+Expectation macros → `ls metadata/expectations/`, and that listing is the whole
+list. CLI flags → `starlake <command> --help`. A key you half-remember from
+documentation is not evidence: if you cannot point to where a name comes from,
+do not write it.
+
+**3 — Cite where each answer came from.** For every non-trivial claim, name the
+file you read or the command you ran. "According to `metadata/load/x/y.sl.yml`"
+is an answer; "typically, Starlake uses…" is a guess wearing an answer's clothes.
+
+**4 — Run the gate. Do not predict it.** After any change to `metadata/`, run
+`starlake validate` — and `starlake test` / `starlake dag-generate` when they
+apply — and report the real output. Never write "this should validate".
+
+**5 — Change only what was asked.** One table, one task, one file. Do not
+reformat, reorder attributes, "fix" neighbouring files, or delete comments you
+did not write. Attribute order is part of a table's contract.
+
+**6 — "I checked, and it is not there" is a correct answer.** So is "I don't
+know". A plausible answer that turns out to be invented costs more than a
+question.
+
+---
+
+## Before you answer — look here first
+
+| The question is about… | Read or run this before answering |
+|---|---|
+| which domains / tables exist | `ls metadata/load/` then `ls metadata/load/<domain>/` |
+| a table's columns, types, write strategy | `metadata/load/<domain>/<table>.sl.yml` |
+| which transforms exist | `ls metadata/transform/` and its `*.sl.yml` + `*.sql` pairs |
+| which expectation macros are available | `ls metadata/expectations/` — these `.j2` files are the whole list |
+| which types are available | `metadata/types/types.sl.yml` and `default.sl.yml` |
+| which connection / engine is active | `metadata/env.sl.yml`, then `starlake settings` |
+| what a load or transform actually did | the `audit.audit` table |
+| why a row was rejected | the `audit.rejected` table |
+| whether a declared rule passed | the `audit.expectations` table |
+| what feeds what | `starlake lineage`, `starlake col-lineage`, `starlake table-dependencies` |
+| which DAG templates ship here | `ls metadata/dags/` |
+| any `.sl.yml` key you are unsure of | `metadata/starlake.json` |
+| any CLI flag you are unsure of | `starlake <command> --help` |
+
+---
+
+## The authorities, in order
+
+When they disagree, the earlier one wins.
+
+1. **This project's files** — `metadata/**`, `metadata/starlake.json`,
+   `metadata/expectations/*.j2`, `metadata/types/*.sl.yml`.
+2. **`starlake <command> --help`** — the flags this CLI version actually accepts.
+3. **The installed Starlake skills** — one per CLI command, plus configuration
+   and best-practice skills. Consult the skill for a command *before* writing
+   that command.
+4. **Nothing else.** Not your memory of the documentation, not a blog post, not
+   another Starlake project.
+
+---
+
+## The gate
+
+```bash
+starlake validate                                  # the YAML is well-formed and coherent
+starlake test                                      # the unit tests, when the project has any
+starlake dag-generate --clean --outputDir out/dags # the orchestration still generates
+```
+
+Two things about this CLI you must not misread:
+
+- **It is silent on success.** Exit code 0 with empty stdout means it worked, not
+  that it did nothing. Prefix a command with `SL_LOG_LEVEL=info` to see the SQL it
+  ran, the write strategy it applied and the audit rows it inserted.
+- **`validate` judges the YAML, not the result.** A configuration can validate
+  perfectly and still load the wrong rows. Only the data and the `audit.*` tables
+  tell you what happened.
+
+Before running any `starlake` command, check the CLI is on the PATH with
+`starlake --version`; if it is not, ask for its path rather than guessing one. On
+Windows the command is `starlake.cmd`.
+
+---
+
+## Reading what actually happened
+
+The audit tables live in the same warehouse as the data.
+
+| Table | Answers |
+|---|---|
+| `audit.audit` | what ran: domain, table, step (`LOAD` / `TRANSFORM`), counts, success |
+| `audit.rejected` | which rule stopped a row, and which file it came from |
+| `audit.expectations` | which declared data-quality rule passed or failed, and its count |
+
+Never describe what one of these tables holds from memory — read its columns
+first. An audit table that does not store what you are about to hand back is a
+trap you can only avoid by looking:
+
+```bash
+starlake transform --name __ignore__.__ignore__ --query "describe audit.rejected" --interactive csv
+```
+
+`__ignore__.__ignore__` is the CLI's sentinel for "no task, just run this SQL";
+any other name must resolve to a task that exists.
+
+---
+
+## The skills are your manual
+
+A Starlake skill is installed for every CLI command and for the main
+configuration topics. They are the reference for syntax and options — read the
+relevant one instead of recalling it.
+
+- Claude Code: `~/.claude/skills/`
+- Gemini CLI: `~/.gemini/skills/`
+- GitHub Copilot: `~/.copilot/skills/`
+
+**The directory listing is the authoritative catalogue** — run `ls` on it rather
+than trusting the list below, which names only the ones a project like this one
+uses most:
+
+- **Project & config** — `config`, `connection`, `settings`, `validate`,
+  `bootstrap`, `migrate`, `console`, `serve`
+- **Schema discovery** — `infer-schema`, `autoload`, `preload`, `extract-schema`,
+  `extract-data`, `extract-bq-schema`, `extract-rest-schema`, `extract-rest-data`
+- **Loading** — `stage`, `load`, `ingest`, `cnxload`, `esload`, `kafkaload`
+- **Data quality** — `expectations`, `test`, `metrics`, `summarize`, `freshness`
+- **Transforms & lineage** — `transform`, `lineage`, `col-lineage`,
+  `table-dependencies`, `acl-dependencies`
+- **Semantic & catalog** — `semantic`, `semantic-export`, `site`, `secure`,
+  `iam-policies`
+- **Orchestration** — `dag-generate`, `dag-create`, `dag-template-generate`,
+  `dag-deploy`
+
+**Starflow** adds a guided methodology on top: expert personas
+(`starflow-data-architect`, `starflow-data-engineer`,
+`starflow-data-quality-engineer`, `starflow-data-analyst`,
+`starflow-platform-engineer`) and workflow skills
+(`starflow-create-pipeline-spec`, `starflow-dev-pipeline`,
+`starflow-schema-design`, `starflow-transform-design`,
+`starflow-semantic-model-design`, `starflow-orchestration-design`,
+`starflow-code-review`, `starflow-data-quality-review`,
+`starflow-lineage-review`, `starflow-help`).
+
+They are installed from [starlake-ai/starlake-skills](https://github.com/starlake-ai/starlake-skills);
+if the directory is empty, say so rather than guessing a command's options.
+
+---
+
+## Configuration conventions
+
+- All metadata files use the `.sl.yml` extension and start with `version: 1`
+- Variables use `{{VAR_NAME}}` Mustache-style templating, resolved from the env
+  files or the shell environment
+- Load tables define `pattern`, `metadata.format` (DSV / JSON / JSON_FLAT…) and a
+  `writeStrategy`
+- Transform tasks pair a `.sl.yml` (columns, domain, write strategy) with a `.sql`
+  file holding the query
+- Data-quality expectations in `metadata/expectations/` are Jinja2 macros invoked
+  as `{{ macro_name(table, column, ...) }}`
+- `metadata/starlake.json` is the JSON Schema for every `.sl.yml`, which is what
+  gives an editor its validation and completion
+
+---
+
+## How to hand back a change
+
+1. Say what you read to decide (files, commands).
+2. Show the diff, minimal, one concern at a time.
+3. Run the gate and paste its **real** output.
+4. State plainly what you did not verify, and what you would check next.
+
+If a request is ambiguous — two tables could be meant, two write strategies would
+both work — ask, or state the assumption in one line and proceed. Do not silently
+pick one and present it as the only reading.

--- a/src/main/resources/templates/bootstrap/samples/sample-project/CLAUDE.md
+++ b/src/main/resources/templates/bootstrap/samples/sample-project/CLAUDE.md
@@ -1,99 +1,41 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code working in this **Starlake / Starflow** project.
 
-## Project Overview
+The full contract is in [AGENTS.md](AGENTS.md) — what this project contains, where
+to look things up, and how to hand back a change. Read it before your first edit.
+The rules below are the part you must never skip.
 
-This is a **Starlake Starflow** data pipeline project ("StarBake") — a sample bakery analytics system demonstrating data ingestion, transformation, and KPI computation. The default engine is **DuckDB** (configurable via environment files).
+@AGENTS.md
 
-## Starflow CLI
+## Ground rules
 
-Before running any `starlake` command, verify the CLI is available in the PATH by running `starlake --version`. If not found, ask the user for the path to the starlake executable. On Windows, the command is `starlake.cmd` instead of `starlake`.
+**1 — Never assume. Read the project first.**
+Do not answer a question about this project from a template, from a sample you
+have seen elsewhere, or from an earlier turn in the conversation. List the
+directory, open the file, run the command. A name that looks familiar because
+another Starlake project uses it is a reason to check, not a reason to trust.
 
-The CLI is silent by default — exit code 0 with empty stdout means success, not a no-op. To see execution logs (SQL run, write strategies, audit inserts), prefix the command with `SL_LOG_LEVEL=info`.
+**2 — Never invent syntax.** YAML keys, CLI flags, expectation macro names and
+write strategies either exist in this project's authorities or they do not
+exist. YAML keys → `metadata/starlake.json`, the JSON Schema for every `.sl.yml`.
+Expectation macros → `ls metadata/expectations/`, and that listing is the whole
+list. CLI flags → `starlake <command> --help`. A key you half-remember from
+documentation is not evidence: if you cannot point to where a name comes from,
+do not write it.
 
-## Key Commands
+**3 — Cite where each answer came from.** For every non-trivial claim, name the
+file you read or the command you ran. "According to `metadata/load/x/y.sl.yml`"
+is an answer; "typically, Starlake uses…" is a guess wearing an answer's clothes.
 
-```bash
-# Validate project configuration
-starlake validate
+**4 — Run the gate. Do not predict it.** After any change to `metadata/`, run
+`starlake validate` — and `starlake test` / `starlake dag-generate` when they
+apply — and report the real output. Never write "this should validate".
 
-# Load source data (CSV/JSON) into the warehouse
-# Always specify --domains, --tables, and --files explicitly
-starlake load --domains starbake --tables customers --files "${SL_ROOT}/datasets/incoming/starbake/customers.csv"
-starlake load --domains starbake --tables orders --files "${SL_ROOT}/datasets/incoming/starbake/orders.json"
-starlake load --domains starbake --tables products --files "${SL_ROOT}/datasets/incoming/starbake/products.json"
+**5 — Change only what was asked.** One table, one task, one file. Do not
+reformat, reorder attributes, "fix" neighbouring files, or delete comments you
+did not write. Attribute order is part of a table's contract.
 
-# Run a specific transformation
-starlake transform --name starbake_analytics.customer_purchase_history
-starlake transform --name starbake_analytics.order_items_analysis
-starlake transform --name starbake_kpis.overall_kpis
-# Run a transformation (use --recursive to execute all upstream dependencies in order)
-starlake transform --name starbake_kpis.overall_kpis --recursive
-
-# Auto-infer schema and load
-starlake autoload
-
-# Generate DAGs for orchestration
-starlake dag-generate
-
-# Print settings / test a connection
-starlake settings
-
-# Run integration tests
-starlake test
-
-# Switch environment (default: DuckDB)
-export SL_ENV=BQ        # BigQuery
-export SL_ENV=PG        # PostgreSQL
-export SL_ENV=SNOW      # Snowflake
-export SL_ENV=REDSHIFT  # Redshift
-```
-
-## Architecture
-
-### Data Pipeline Flow
-
-```
-datasets/incoming/starbake/     →  Load (metadata/load/)
-    customers.*.csv                    ↓
-    orders.*.json               →  starbake domain tables
-    products.*.json                    ↓
-                                   Transform (metadata/transform/)
-                                       ↓
-                               starbake_analytics/
-                                 ├─ customer_purchase_history
-                                 └─ order_items_analysis
-                                       ↓
-                               starbake_kpis/
-                                 └─ overall_kpis
-```
-
-### Project Structure
-
-- **`metadata/application.sl.yml`** — Main config: connections (DuckDB, BigQuery, Snowflake, PostgreSQL, Redshift), DAG references, schedule presets
-- **`metadata/env.sl.yml`** — Default env vars (`activeConnection: duckdb`). Override with `metadata/env.{BQ,PG,SNOW,...}.sl.yml`
-- **`metadata/load/starbake/`** — Source table schemas (3 tables). Each `.sl.yml` defines pattern, format, attributes, write strategy
-- **`metadata/transform/`** — SQL transformations with paired `.sl.yml` (task metadata) + `.sql` (query) files
-- **`metadata/types/`** — Custom data types with DDL mappings for each engine
-- **`metadata/expectations/`** — Jinja2 data quality templates (completeness, uniqueness, volume, etc.)
-- **`metadata/dags/`** — DAG definitions for Airflow (shell/Cloud Run/Fargate), Dagster, and Snowflake native
-- **`metadata/external/`** — External table definitions for reading outputs
-- **`datasets/`** — Sample data files and DuckDB database
-
-### Configuration Conventions
-
-- All metadata files use `.sl.yml` extension and start with `version: 1`
-- Variables use `{{VAR_NAME}}` Mustache-style templating, resolved from env files or shell environment
-- Load tables define `pattern`, `metadata.format` (DSV/JSON_FLAT), and `writeStrategy`
-- Transform tasks pair a `.sl.yml` (columns, domain, write strategy) with a `.sql` file (query logic)
-- SQL uses DuckDB syntax by default; alternative Snowflake/Redshift syntax is often commented in `.sql` files
-
-
-<claude-mem-context>
-# Recent Activity
-
-<!-- This section is auto-generated by claude-mem. Edit content outside the tags. -->
-
-*No recent activity*
-</claude-mem-context>
+**6 — "I checked, and it is not there" is a correct answer.** So is "I don't
+know". A plausible answer that turns out to be invented costs more than a
+question.

--- a/src/main/resources/templates/bootstrap/samples/sample-project/GEMINI.md
+++ b/src/main/resources/templates/bootstrap/samples/sample-project/GEMINI.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# GEMINI.md
 
-Guidance for Claude Code working in this **Starlake / Starflow** project.
+Guidance for Gemini working in this **Starlake / Starflow** project.
 
 The full contract is in [AGENTS.md](AGENTS.md) — what this project contains, where
 to look things up, and how to hand back a change. Read it before your first edit.

--- a/src/main/resources/templates/bootstrap/samples/sample-project/README.md
+++ b/src/main/resources/templates/bootstrap/samples/sample-project/README.md
@@ -1,0 +1,126 @@
+# StarBake
+
+**StarBake** is a fictional bakery, and this project is its data pipeline: raw
+operational files in, business insight out. It exists to be read and run — every
+Starlake concept it uses is small enough to hold in your head, and the whole thing
+runs on DuckDB with no account to create and nothing to configure.
+
+## What this project ships
+
+Three sources are loaded into the `starbake` domain:
+
+| Table | Arrives as | Pattern | Write strategy |
+| --- | --- | --- | --- |
+| `starbake.customers` | CSV (`DSV`) | `customers.*.csv` | `APPEND` |
+| `starbake.orders` | JSON (`JSON_FLAT`) | `orders.*.json` | `APPEND` |
+| `starbake.products` | JSON (`JSON_FLAT`) | `products.*.json` | `APPEND` |
+
+Three transformations read from them:
+
+| Task | Produces |
+| --- | --- |
+| `starbake_analytics.customer_purchase_history` | one row per customer: `total_orders`, `total_spent`, `first_order_date`, `last_order_date` |
+| `starbake_analytics.order_items_analysis` | one row per order: `purchased_items`, `total_order_value` |
+| `starbake_kpis.overall_kpis` | one row for the whole business: revenue, order and customer averages, lifetime and rate indicators |
+
+```mermaid
+classDiagram
+    customers --|> customer_purchase_history: uses
+    orders --|> customer_purchase_history: uses
+    orders --|> order_items_analysis: uses
+    products --|> order_items_analysis: uses
+    customer_purchase_history --|> overall_kpis: uses
+    order_items_analysis --|> overall_kpis: uses
+
+    class customer_purchase_history {
+        +customer_id
+        +customer_name
+        +email
+        +total_orders
+        +total_spent
+        +first_order_date
+        +last_order_date
+    }
+
+    class order_items_analysis {
+        +order_id
+        +order_date
+        +customer_id
+        +purchased_items
+        +total_order_value
+    }
+
+    class overall_kpis {
+        +total_customers
+        +total_orders
+        +total_revenue
+        +avg_order_value
+        +avg_orders_per_customer
+        +avg_spent_per_customer
+        +earliest_order_date
+        +latest_order_date
+        +avg_customer_lifetime_days
+        +avg_categories_per_customer
+        +customer_order_rate
+    }
+```
+
+Nothing declares that order: `overall_kpis` reads the two analytics tables in its
+SQL, and Starlake works the dependency out from there. `--recursive` runs the
+upstream tasks first.
+
+## How to run it
+
+```bash
+export SL_ROOT=$PWD
+starlake validate
+
+starlake load --domains starbake --tables customers --files "${SL_ROOT}/datasets/incoming/starbake/customers.csv"
+starlake load --domains starbake --tables orders    --files "${SL_ROOT}/datasets/incoming/starbake/orders.json"
+starlake load --domains starbake --tables products  --files "${SL_ROOT}/datasets/incoming/starbake/products.json"
+
+starlake transform --name starbake_kpis.overall_kpis --recursive
+```
+
+The CLI is **silent on success**: exit code 0 with no output means it worked, not
+that it did nothing. Prefix any command with `SL_LOG_LEVEL=info` to see the SQL it
+ran, the write strategy it applied and the audit rows it inserted. What actually
+happened is in the `audit.audit`, `audit.rejected` and `audit.expectations`
+tables, in the same `datasets/duckdb.db` as your data.
+
+Switch engine with `SL_ENV`, which selects `metadata/env.<NAME>.sl.yml`:
+`BQ` (BigQuery), `PG` (PostgreSQL), `SNOW` (Snowflake), `REDSHIFT`. Unset means
+the base `env.sl.yml`, which is DuckDB.
+
+## Where to take it next
+
+The bakery scenario is deliberately larger than what ships here, and the gap is
+the exercise. Suppliers, Ingredients and ProductIngredients are part of the story
+but **have no table in this project**; neither do the analytics it would make
+possible — product profitability needs ingredient costs, and a lifetime-value or
+top-selling-products table needs nothing that is not already loaded.
+
+Good next steps, roughly in order of effort:
+
+1. add an expectation to `starbake.customers` — the macros you can call are the
+   `.j2` files in `metadata/expectations/`;
+2. give `customers` a real write strategy: `APPEND` duplicates rows when you
+   reload the same file, `UPSERT_BY_KEY` does not;
+3. add a fourth source (ingredients, suppliers) with
+   `starlake infer-schema`, and a transform that uses it;
+4. generate the orchestration — `starlake dag-generate` — and look at what
+   `metadata/dags/` gave you.
+
+## Working with an AI assistant
+
+`AGENTS.md` is the contract your assistant reads: what this project contains,
+where to look each thing up, and the rules it must follow — read the project
+rather than assume it, never invent a YAML key or a macro name, run
+`starlake validate` instead of predicting it. `CLAUDE.md`, `GEMINI.md` and
+`.github/copilot-instructions.md` point at it, each in the file its own assistant
+loads. Keep them in step with the project as it grows.
+
+## Where to go next
+
+- [starlake.ai](https://starlake.ai) — product site and documentation
+- `starlake --help`, and `starlake <command> --help` for any command

--- a/src/main/resources/templates/bootstrap/samples/sample-project/copilot-instructions.md
+++ b/src/main/resources/templates/bootstrap/samples/sample-project/copilot-instructions.md
@@ -1,12 +1,10 @@
-# CLAUDE.md
+# Copilot instructions
 
-Guidance for Claude Code working in this **Starlake / Starflow** project.
+Guidance for GitHub Copilot working in this **Starlake / Starflow** project.
 
-The full contract is in [AGENTS.md](AGENTS.md) — what this project contains, where
-to look things up, and how to hand back a change. Read it before your first edit.
-The rules below are the part you must never skip.
-
-@AGENTS.md
+The full contract is in `AGENTS.md` at the project root — what this project
+contains, where to look things up, and how to hand back a change. Read it before
+your first edit. The rules below are the part you must never skip.
 
 ## Ground rules
 

--- a/src/main/scala/ai/starlake/job/bootstrap/Bootstrap.scala
+++ b/src/main/scala/ai/starlake/job/bootstrap/Bootstrap.scala
@@ -14,6 +14,12 @@ import scala.util.Try
 
 object Bootstrap extends LazyLogging {
   val TEMPLATES_DIR = "templates/bootstrap/samples"
+
+  // GitHub Copilot reads its instructions from .github/, not from the project
+  // root. Resources cannot ship a dot-folder portably, so each template keeps the
+  // file at its own root and bootstrap places it - the same shape as .gitignore.
+  private val COPILOT_INSTRUCTIONS = "copilot-instructions.md"
+
   private def copyToFolder(
     resources: List[String],
     templateFolder: String,
@@ -131,9 +137,19 @@ object Bootstrap extends LazyLogging {
         val rootFolder = metadataFolder.parent
         val templatePath = s"$TEMPLATES_DIR/$template/"
 
-        // copy template files
+        // copy template files, minus the one that belongs in .github/
         val bootstrapFiles = JarUtil.getResourceFiles(templatePath)
-        copyToFolder(bootstrapFiles, templatePath, rootFolder)
+        val (copilotFiles, rootFiles) =
+          bootstrapFiles.partition(_.endsWith(s"/$COPILOT_INSTRUCTIONS"))
+        copyToFolder(rootFiles, templatePath, rootFolder)
+
+        // the assistant context files land at the project root (AGENTS.md,
+        // CLAUDE.md, GEMINI.md) except Copilot's, which is read from .github/
+        if (copilotFiles.nonEmpty) {
+          val githubFolder = rootFolder / ".github"
+          githubFolder.createDirectories()
+          copyToFolder(copilotFiles, templatePath, githubFolder)
+        }
 
         val agentFolder = File(rootFolder, ".claude")
         agentFolder.createDirectories()

--- a/src/test/scala/ai/starlake/job/bootstrap/BootstrapTemplatesSpec.scala
+++ b/src/test/scala/ai/starlake/job/bootstrap/BootstrapTemplatesSpec.scala
@@ -73,6 +73,31 @@ class BootstrapTemplatesSpec extends AnyFlatSpec with Matchers {
     }
   }
 
+  it should "not link to a document it does not ship" in {
+    // empty-project's README pointed at a HOW_TO_RUN.md that exists in neither
+    // template: a reader follows it, an assistant quotes it, and nothing is there.
+    val link = """\[[^\]]*\]\(([^)]+)\)""".r
+    templatesWithContext.foreach { template =>
+      val shipped = JarUtil
+        .getResourceFiles(s"$templatesDir$template/")
+        .map(_.substring(s"$templatesDir$template/".length))
+        .toSet
+      (contextFiles :+ "README.md").foreach { file =>
+        resource(s"$templatesDir$template/$file").foreach { content =>
+          link
+            .findAllMatchIn(content)
+            .map(_.group(1))
+            .filterNot(t => t.startsWith("http") || t.startsWith("#") || t.startsWith("mailto:"))
+            .foreach { target =>
+              withClue(s"$template/$file links to $target, which the template does not ship: ") {
+                shipped.contains(target.takeWhile(_ != '#')) shouldBe true
+              }
+            }
+        }
+      }
+    }
+  }
+
   it should "not describe the sample project inside the empty one" in {
     // empty-project's CLAUDE.md and README used to be copies of sample-project's,
     // describing a starbake domain and tables that an empty project never has.

--- a/src/test/scala/ai/starlake/job/bootstrap/BootstrapTemplatesSpec.scala
+++ b/src/test/scala/ai/starlake/job/bootstrap/BootstrapTemplatesSpec.scala
@@ -1,0 +1,88 @@
+package ai.starlake.job.bootstrap
+
+import ai.starlake.utils.JarUtil
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.io.{Codec, Source}
+
+/** Every bootstrap template ships the context an AI assistant reads before it answers anything.
+  * They are four separate files because each assistant loads a different one - Claude Code
+  * CLAUDE.md, Gemini GEMINI.md and nothing else, Copilot .github/copilot-instructions.md - so a
+  * missing one is a silent loss of context, not a visible error.
+  */
+class BootstrapTemplatesSpec extends AnyFlatSpec with Matchers {
+
+  private val templatesDir = Bootstrap.TEMPLATES_DIR + "/"
+  private val contextFiles =
+    List("AGENTS.md", "CLAUDE.md", "GEMINI.md", "copilot-instructions.md")
+
+  private def resource(path: String): Option[String] =
+    Option(getClass.getClassLoader.getResourceAsStream(path)).map { in =>
+      try Source.fromInputStream(in)(Codec.UTF8).mkString
+      finally in.close()
+    }
+
+  /** The rules block alone: from its heading to the next horizontal rule, or to the end of the
+    * file. AGENTS.md continues past it, the three per-assistant files stop there, so slicing to EOF
+    * would compare a section against a whole document.
+    */
+  private def rulesOf(content: String): String = {
+    val start = content.indexOf("## Ground rules")
+    if (start < 0) ""
+    else {
+      val body = content.substring(start)
+      val end = body.indexOf("\n---")
+      (if (end < 0) body else body.substring(0, end)).trim
+    }
+  }
+
+  private def templatesWithContext: List[String] =
+    JarUtil
+      .getResourceFolders(templatesDir)
+      .filter(t => contextFiles.exists(f => resource(s"$templatesDir$t/$f").isDefined))
+
+  behavior of "the bootstrap templates"
+
+  it should "ship the two documented templates" in {
+    templatesWithContext should contain allOf ("empty-project", "sample-project")
+  }
+
+  it should "give every assistant the file it actually reads" in {
+    templatesWithContext.foreach { template =>
+      contextFiles.foreach { file =>
+        withClue(s"$template is missing $file: ") {
+          resource(s"$templatesDir$template/$file") shouldBe defined
+        }
+      }
+    }
+  }
+
+  it should "state the same ground rules in all four, so they cannot drift apart" in {
+    templatesWithContext.foreach { template =>
+      val rules = contextFiles.map { file =>
+        val content = resource(s"$templatesDir$template/$file").getOrElse("")
+        withClue(s"$template/$file has no '## Ground rules' section: ") {
+          rulesOf(content) should not be empty
+        }
+        rulesOf(content)
+      }
+      withClue(s"the ground rules differ between $template's context files: ") {
+        rules.distinct should have size 1
+      }
+    }
+  }
+
+  it should "not describe the sample project inside the empty one" in {
+    // empty-project's CLAUDE.md and README used to be copies of sample-project's,
+    // describing a starbake domain and tables that an empty project never has.
+    val docs = contextFiles :+ "README.md"
+    docs.foreach { file =>
+      resource(s"${templatesDir}empty-project/$file").foreach { content =>
+        withClue(s"empty-project/$file mentions the sample project: ") {
+          content.toLowerCase should not include "starbake"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## The problem

A bootstrapped project shipped **one** context file, `CLAUDE.md`, and
`empty-project`'s copy was a verbatim copy of `sample-project`'s: a `starbake`
domain, three tables, two transform domains and `datasets/incoming/starbake/`
paths that an empty project never has. Its `README.md` was the same copy — the
full StarBake specification, six tables and a BigQuery warehouse, in a project
with no domains at all.

The other assistants got nothing at all. **Gemini reads `GEMINI.md` and only
`GEMINI.md`** (checked in the Gemini CLI 0.55.1 bundle: 20 occurrences of
`"GEMINI.md"`, zero of `"AGENTS.md"`); Copilot reads
`.github/copilot-instructions.md`. Neither file existed.

So out of the box one assistant started from a description of a different
project, and the others from no description at all.

## What lands

Both templates now ship four files:

- **`AGENTS.md`** — the contract: what the project contains, a
  question-to-command lookup table, the order of authorities (the project's
  files, then `--help`, then the installed skills, then nothing), the gate, the
  audit tables, the skills catalogue, and six ground rules — read the project
  rather than assume it, never invent a YAML key or a macro name, cite what you
  read, run `starlake validate` instead of predicting it, change only what was
  asked, and say so when you do not know.
- **`CLAUDE.md`**, **`GEMINI.md`**, **`copilot-instructions.md`** — each imports
  `AGENTS.md` **and repeats the six rules verbatim**, because an import that is
  silently not followed is a failure nobody can see.

`sample-project`'s `AGENTS.md` **keeps everything its `CLAUDE.md` declared** —
overview, commands, pipeline flow, layout, the implicit transform dependency
order, the configuration conventions — because all of it is true of that
template. Only `empty-project`'s copy was the lie.

Two of those inherited claims did not survive checking and are gone:

- no `.sql` file carries a Snowflake or Redshift variant — the commented lines
  are alternative spellings for DuckDB (`LIST` beside `ARRAY_AGG`);
- the skills live in `~/.claude/skills`, not in the project's own `.claude/`,
  which bootstrap creates empty.

A `<claude-mem-context>` block that a local tool had written into the committed
`sample-project/CLAUDE.md` goes with them.

## The one code change

Copilot's file cannot simply sit at the template root. Resources cannot ship a
dot-folder portably — there is no precedent for one anywhere under
`src/main/resources` — so each template keeps `copilot-instructions.md` at its
own root and `Bootstrap` places it into `.github/`, the same shape already used
for `.gitignore` and `.vscode`. It is excluded from the generic copy so no stray
copy is left at the project root.

## Tests

`BootstrapTemplatesSpec` asserts what the change is for:

- every template that ships any context file ships **all four**;
- no document links to a file the template does not ship;
- the ground rules are **byte-identical** across the four, so they cannot drift;
- `empty-project` mentions `starbake` nowhere, context files and README alike.

Each assertion was broken and confirmed red before being left green: removing a
template's `GEMINI.md` fails two of them, letting `starbake` back into
`empty-project/README.md` fails the third.

End to end, `bootstrap --template sample-project` and
`bootstrap --template empty-project` both produce `AGENTS.md`, `CLAUDE.md` and
`GEMINI.md` at the project root and `copilot-instructions.md` in `.github/`, with
nothing stray at the root.

## The StarBake story moves to the project that tells it

`empty-project`'s README **was** the StarBake specification, so taking it out of
an empty project left `sample-project` — the one that actually is StarBake — with
no README at all. It now has one, and the story survives.

It did not move verbatim, because that would have relocated the defect rather
than fixed it. The old document describes **six source tables and eight analytics
tables and ticks every one of them off as done**. `sample-project` has three
sources and three transforms. Suppliers, Ingredients, ProductIngredients,
CustomerLifetimeValue, ProductPerformance, ProductProfitability,
HighValueCustomers, TopSellingProducts, MostProfitableProducts and
TopSellingProfitableProducts exist in **none** of them. It names BigQuery as the
warehouse, where the template defaults to DuckDB. And it sends the reader to a
`HOW_TO_RUN.md` that neither template ships.

The bakery therefore keeps its story and loses the promises: the README states
what is really loaded (formats, patterns, write strategies), what the three
transforms really produce, and a class diagram of those. The wider scenario is
still there, in a section that says plainly those tables are not implemented and
offers them as the exercise.

`BootstrapTemplatesSpec` gains the check for the class of bug that dead link is:
**every relative markdown link in a template's own documents must resolve to a
file that template ships.** Re-adding the `HOW_TO_RUN.md` line fails it.

## Noted, not touched

- `Bootstrap` creates an empty `.claude/` folder and declares
  `val agentPath = "templates/agent/"` that nothing uses — an unfinished feature
  that leaves an empty directory in every project it creates.
- `BootstrapSpec` is wrapped in `if (false)` and asserts nothing. The new spec
  does not replace it: it tests the resources, not the copy.
