### PR TITLE
build: compile Java sources with --release 17

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,7 @@ lazy val javacCompilerVersion = "17"
 
 
 javacOptions ++= Seq(
-  "-source", javacCompilerVersion,
-  "-target", javacCompilerVersion,
+  "--release", javacCompilerVersion,
   "-Xlint"
 )
 


### PR DESCRIPTION
## Problem

`build.sbt` passed `-source 17 -target 17` to javac. That pins the *bytecode* version but not the *API* the three Java sources compile against: javac still resolves them against the build JDK's class library. On a JDK 21 or 26 machine, one of them could reference a post-17 method, compile without error, and fail at runtime with `NoSuchMethodError` for users on JDK 17, which is the documented minimum and what CI builds with.

It also emits the `bootstrap class path not set in conjunction with -source 17` warning on every build.

## Fix

Use `--release 17`, which compiles against the real JDK 17 API signatures, so an out-of-range API becomes a build error on any JDK.

Note the flag needs **two** dashes. `javac -release 17` fails with `error: invalid flag: -release`.

## Verification

`sbt compile` on JDK 21, clean:

```
[success] Total time: 28 s
```

The three javac-compiled classes still carry Java 17 bytecode:

| class | major version |
|---|---|
| `Setup.class` | 61 |
| `SupportedCustomDataType.class` | 61 |
| `BigQuerySchemaConverters.class` | 61 |

No behavior change for Scala sources: scalac has no target set in this build, so it emits Java 8 bytecode (major 52) as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)