### PR TITLE
test: sync test goldens with the Starflow rebrand

### DIFF
--- a/src/test/scala/ai/starlake/extract/ExtractSpec.scala
+++ b/src/test/scala/ai/starlake/extract/ExtractSpec.scala
@@ -710,7 +710,7 @@ class ExtractSpec extends TestHelper {
       s"""
         |Usage: starlake extract-data [options]
         |
-        |Extract data from a JDBC database into CSV or Parquet files. Supports incremental extraction, parallel partitioning, and selective table filtering for efficient large-scale data exports. See [Extract Tutorial](/guides/extract/tutorial).
+        |Extract data from a JDBC database into CSV or Parquet files. Supports incremental extraction, parallel partitioning, and selective table filtering for efficient large-scale data exports. See [Extract Tutorial](/starflow/guides/extract/tutorial).
         |
         |Extract data from any database defined in mapping file.
         |
@@ -763,7 +763,7 @@ class ExtractSpec extends TestHelper {
     val expected =
       """
         |Usage: starlake extract-schema [options]
-        |Extract table schemas from a JDBC database and generate Starlake YAML configuration files. Use this to reverse-engineer existing database tables into domain definitions with optional snake_case naming. See [Extract Tutorial](/guides/extract/tutorial).
+        |Extract table schemas from a JDBC database and generate Starflow YAML configuration files. Use this to reverse-engineer existing database tables into domain definitions with optional snake_case naming. See [Extract Tutorial](/starflow/guides/extract/tutorial).
         |  --config <value>        Database tables & connection info
         |  --all                    Should we extract all schemas and tables to external folder ?
         |  --tables <value>         Database tables info

--- a/src/test/scala/ai/starlake/job/infer/InferSchemaInfoSpec.scala
+++ b/src/test/scala/ai/starlake/job/infer/InferSchemaInfoSpec.scala
@@ -9,7 +9,7 @@ class InferSchemaInfoSpec extends TestHelper {
       val expected =
         """
           |Usage: starlake infer-schema [options]
-          |Infer a Starlake table schema from a sample data file (CSV, JSON, etc.) and generate the corresponding YAML configuration. See [Load Tutorial](/guides/load/tutorial).
+          |Infer a Starflow table schema from a sample data file (CSV, JSON, etc.) and generate the corresponding YAML configuration. See [Load Tutorial](/starflow/guides/load/tutorial).
           |
           |  --domain <value>       Domain Name
           |  --table <value>        Table Name

--- a/src/test/scala/ai/starlake/job/metrics/MetricsJobSpec.scala
+++ b/src/test/scala/ai/starlake/job/metrics/MetricsJobSpec.scala
@@ -168,7 +168,7 @@ class MetricsJobSpec extends TestHelper with JdbcChecks {
       val expected =
         """
           |Usage: starlake metrics [options]
-          |Compute data quality metrics (continuous, discrete, and frequency metrics) on loaded tables. See [Metrics Guide](/guides/load/metrics).
+          |Compute data quality metrics (continuous, discrete, and frequency metrics) on loaded tables. See [Metrics Guide](/starflow/guides/load/metrics).
           |  --domain <value>   Domain Name
           |  --schema <value>   Schema Name
           |  --authInfo <value> Auth Info.  Google Cloud use: gcpProjectId and gcpSAJsonKey

--- a/src/test/scala/ai/starlake/schema/generator/Xls2YmlDomainsSpec.scala
+++ b/src/test/scala/ai/starlake/schema/generator/Xls2YmlDomainsSpec.scala
@@ -134,13 +134,13 @@ class Xls2YmlDomainsSpec extends TestHelper {
       val expected =
         """
           |Usage: starlake xls2yml [options]
-          |Generate Starlake YAML configuration files from Excel spreadsheets.
+          |Generate Starflow YAML configuration files from Excel spreadsheets.
           |
           |  --files <value>       List of Excel files describing domains & schemas or jobs
           |  --iamPolicyTagsFile <value>
           |                        If true generate IAM PolicyTags YML
           |  --outputDir <value>  Path for saving the resulting YAML file(s).
-          | Starlake domains path is used by default.
+          | Starflow domains path is used by default.
           |  --policyFile <value>  Optional File for centralising ACL & RLS definition.
           |  --job <value>         If true generate YML for a Job.
           |  --reportFormat <value> Report format: console, json, html

--- a/src/test/scala/ai/starlake/schema/generator/Yml2XlsSpec.scala
+++ b/src/test/scala/ai/starlake/schema/generator/Yml2XlsSpec.scala
@@ -83,7 +83,7 @@ class Yml2XlsSpec extends TestHelper {
     val expected =
       """
         |Usage: starlake yml2xls [options]
-        |Export Starlake YAML domain and table definitions to an Excel spreadsheet.
+        |Export Starflow YAML domain and table definitions to an Excel spreadsheet.
         |
         |  --domain <value>  domains to convert to XLS
         |  --iamPolicyTagsFile <value>

--- a/src/test/scala/ai/starlake/semantic/LookMLConverterSpec.scala
+++ b/src/test/scala/ai/starlake/semantic/LookMLConverterSpec.scala
@@ -198,7 +198,7 @@ class LookMLConverterSpec extends AnyFlatSpec with Matchers {
       LookMLConverter.convert("unowned_metric_model", YamlSerde.mapper.readTree(yaml), "wh").toMap
     val orders = files("orders.view.lkml")
     orders should include(
-      "# starlake: verify this measure, expression could not be mapped to a native LookML type"
+      "# starflow: verify this measure, expression could not be mapped to a native LookML type"
     )
     orders should include("measure: total_revenue {")
     orders should include("type: number")
@@ -221,7 +221,7 @@ class LookMLConverterSpec extends AnyFlatSpec with Matchers {
       LookMLConverter.convert("fallback_model", YamlSerde.mapper.readTree(yaml), "wh").toMap
     val sales = files("sales.view.lkml")
     sales should include(
-      "# starlake: verify this measure, expression could not be mapped to a native LookML type"
+      "# starflow: verify this measure, expression could not be mapped to a native LookML type"
     )
     sales should include("measure: weird_ratio {")
     sales should include("type: number")

--- a/src/test/scala/ai/starlake/semantic/TMDLConverterSpec.scala
+++ b/src/test/scala/ai/starlake/semantic/TMDLConverterSpec.scala
@@ -283,7 +283,7 @@ class TMDLConverterSpec extends AnyFlatSpec with Matchers {
         .convert("ecommerce_analytics", YamlSerde.mapper.readTree(modelYaml), None)
         .toMap
         .apply("tables/orders.tmdl")
-    none should include("\t\t\t\t// TODO Starlake: set the connector for your warehouse")
+    none should include("\t\t\t\t// TODO Starflow: set the connector for your warehouse")
     none should include("\t\t\t\tSource = Sql.Database(\"SERVER_TODO\", \"DATABASE_TODO\"),")
 
     val duck = Some(
@@ -294,7 +294,7 @@ class TMDLConverterSpec extends AnyFlatSpec with Matchers {
         .convert("ecommerce_analytics", YamlSerde.mapper.readTree(modelYaml), duck)
         .toMap
         .apply("tables/orders.tmdl")
-    d should include("// TODO Starlake: set the connector for your warehouse")
+    d should include("// TODO Starflow: set the connector for your warehouse")
   }
 
   it should "double embedded double quotes in the M query string" in {
@@ -331,7 +331,7 @@ class TMDLConverterSpec extends AnyFlatSpec with Matchers {
   it should "fall back to BLANK() with the original SQL for untranslatable metrics" in {
     val orders = files()("tables/orders.tmdl")
     orders should include(
-      "\t/// TODO Starlake: translate original SQL to DAX: SUM(a)/NULLIF(SUM(b),0)"
+      "\t/// TODO Starflow: translate original SQL to DAX: SUM(a)/NULLIF(SUM(b),0)"
     )
     orders should include("\tmeasure total_revenue = BLANK()")
   }
@@ -352,7 +352,7 @@ class TMDLConverterSpec extends AnyFlatSpec with Matchers {
       .convert("stray", YamlSerde.mapper.readTree(yaml), None)
       .toMap
       .apply("tables/sales.tmdl")
-    table should include("\t/// TODO Starlake: translate original SQL to DAX: SUM(profit)")
+    table should include("\t/// TODO Starflow: translate original SQL to DAX: SUM(profit)")
     table should include("\tmeasure stray_sum = BLANK()")
   }
 

--- a/src/test/scala/ai/starlake/semantic/TMDLExportSpec.scala
+++ b/src/test/scala/ai/starlake/semantic/TMDLExportSpec.scala
@@ -77,7 +77,7 @@ class TMDLExportSpec extends TestHelper {
       orders should include("\t\tisKey")
       orders should include("\tmeasure avg_order_value = AVERAGE('orders'[order_total])")
       // unknown connection name falls back to the generic source
-      orders should include("// TODO Starlake: set the connector for your warehouse")
+      orders should include("// TODO Starflow: set the connector for your warehouse")
       orders should include("FROM ANALYTICS_DB.ECOMMERCE.ORDERS")
 
       storage.read(new Path(outDir, "relationships.tmdl")) should include(


### PR DESCRIPTION
Fixes 12 of the 16 test failures that CI has been reporting since the 1.8.2 rebrand.

## Root cause

The rebrand updated CLI help text and documentation URLs in `src/main` but not the golden strings in `src/test`. Production is correct; the expectations went stale. Every failure is a string comparison of the form:

```
"...Export Star[flow]YAMLdomainandtablede..." did not equal "...Export Star[lake]YAMLdomainandtablede..."   (Yml2XlsSpec.scala:94)
"...[MetricsGuide](/[starflow/]guides/load/metrics)..." did not equal "...[MetricsGuide](/[]guides/load/metrics)..."  (MetricsJobSpec.scala:177)
```

Confirmed against the production strings, e.g. `MetricsCmd.scala:30` emits `See [Metrics Guide](/starflow/guides/load/metrics)` and `Yml2XlsCmd.scala:36` emits `Export Starflow YAML ...`.

## Changes

16 string replacements across 8 spec files:

- CLI usage text: `Starlake` → `Starflow`, `](/guides/` → `](/starflow/guides/` in `Yml2XlsSpec`, `Xls2YmlDomainsSpec`, `InferSchemaInfoSpec`, `MetricsJobSpec`, `ExtractSpec`
- generated markers: `# starlake: verify` → `# starflow: verify`, `TODO Starlake:` → `TODO Starflow:` in `LookMLConverterSpec`, `TMDLConverterSpec`, `TMDLExportSpec`

No production code touched.

## Verification

`TMDLConverterSpec` and `LookMLConverterSpec` are plain `AnyFlatSpec` and run without Docker:

```
[info] Tests: succeeded 40, failed 0, canceled 0, ignored 0, pending 0
```

That covers 5 of the 12. The other six suites extend `TestHelper`, which starts a PostgreSQL testcontainer, so they need Docker and CI covers them here.

## Not included

The remaining 4 failures (`BigQueryBranchSpec` ×2, `SparkParquetToBigQuerySpec` ×2) have an unrelated environmental cause and are left alone. They fail as `false was not equal to true`, and the underlying error is:

```
Caused by: java.io.IOException: ComputeEngineCredentials cannot find the metadata server.
Caused by: java.net.UnknownHostException: metadata.google.internal
```

gcs-connector 4.0.4 (new with the Spark 4 migration) defaults `google.cloud.auth.type` to `COMPUTE_ENGINE` — verified by disassembling the shipped jar — and `SparkEnv` sets only `spark.hadoop.fs.gs.project.id`, never an auth type. So on a GitHub runner the connector reaches for the GCE metadata server instead of the credentials the workflow exported. Fixing that means setting `google.cloud.auth.type=APPLICATION_DEFAULT` on the Spark session, which is a production change needing real GCP credentials to verify, so it belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)