### PR TITLE
fix: propagate the connection authType to the Spark GCS connector

### DIFF
--- a/src/main/scala/ai/starlake/config/SparkEnv.scala
+++ b/src/main/scala/ai/starlake/config/SparkEnv.scala
@@ -20,6 +20,7 @@
 
 package ai.starlake.config
 
+import ai.starlake.utils.GcpCredentials
 import ai.starlake.utils.Utils
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.SparkConf
@@ -66,22 +67,8 @@ class SparkEnv private (
     if (!isSessionStarted()) {
       val conn = settings.appConfig.getDefaultConnection()
 
-      val isBigQuery = conn.isBigQuery()
-      if (isBigQuery) {
-        val projectId =
-          conn.options
-            .get("projectId")
-            .orElse(Option(com.google.cloud.ServiceOptions.getDefaultProjectId()))
-            .getOrElse(
-              throw new Exception(
-                "define the env variable GOOGLE_CLOUD_PROJECT or set projectId in the connection"
-              )
-            )
-
-        // This sets the billing project for BigQuery
-        config.set("parentProject", conn.options.getOrElse("parentProject", projectId))
-        // This helps if you are using the GCS connector
-        config.set("spark.hadoop.fs.gs.project.id", projectId)
+      if (conn.isBigQuery()) {
+        SparkEnv.bigQueryConf(conn).foreach { case (key, value) => config.set(key, value) }
       }
       val sysProps = System.getProperties()
       if (!SparkSessionBuilder.isSparkConnectActive) {
@@ -210,5 +197,33 @@ object SparkEnv {
       sparkEnv = new SparkEnv(name, settings.jobConf, settings.appConfig.datasets, confTransformer)
     }
     sparkEnv
+  }
+
+  /** Spark properties derived from a BigQuery connection.
+    *
+    * The authType declared on the connection is propagated to the GCS connector used by the Spark
+    * session: gcs-connector defaults `google.cloud.auth.type` to COMPUTE_ENGINE, so without these
+    * keys it queries the GCE metadata server, which only answers on Google infrastructure.
+    */
+  private[starlake] def bigQueryConf(
+    conn: ConnectionInfo
+  )(implicit settings: Settings): Map[String, String] = {
+    val projectId =
+      conn.options
+        .get("projectId")
+        .orElse(Option(com.google.cloud.ServiceOptions.getDefaultProjectId()))
+        .getOrElse(
+          throw new Exception(
+            "define the env variable GOOGLE_CLOUD_PROJECT or set projectId in the connection"
+          )
+        )
+    Map(
+      // This sets the billing project for BigQuery
+      "parentProject" -> conn.options.getOrElse("parentProject", projectId),
+      // This helps if you are using the GCS connector
+      "spark.hadoop.fs.gs.project.id" -> projectId
+    ) ++ GcpCredentials.hadoopAuthConf(conn.options).map { case (key, value) =>
+      s"spark.hadoop.$key" -> value
+    }
   }
 }

--- a/src/main/scala/ai/starlake/schema/handlers/HdfsStorageHandler.scala
+++ b/src/main/scala/ai/starlake/schema/handlers/HdfsStorageHandler.scala
@@ -22,6 +22,7 @@ package ai.starlake.schema.handlers
 
 import ai.starlake.config.Settings
 import ai.starlake.job.sink.bigquery.BigQueryJobBase
+import ai.starlake.utils.GcpCredentials
 import ai.starlake.utils.conversion.Conversions.convertToScalaIterator
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.*
@@ -41,68 +42,6 @@ class HdfsStorageHandler(fileSystem: String)(implicit
   settings: Settings
 ) extends StorageHandler {
   private var _connectionOptions = Map.empty[String, String]
-
-  private def gcpAuthConf(connectionOptions: Map[String, String]): Map[String, String] = {
-    val authType = connectionOptions.getOrElse("authType", "APPLICATION_DEFAULT")
-    val authConf = authType match {
-      case "APPLICATION_DEFAULT" =>
-        Map(
-          "google.cloud.auth.type" -> "APPLICATION_DEFAULT"
-        )
-      /*
-          val gcpAccessToken =
-            GcpUtils.getCredentialUsingWellKnownFile().asInstanceOf[UserCredentials]
-
-          Map(
-            "google.cloud.auth.type"                   -> "USER_CREDENTIALS",
-            "google.cloud.auth.service.account.enable" -> "true",
-            "google.cloud.auth.client.id"              -> gcpAccessToken.getClientId,
-            "google.cloud.auth.client.secret"          -> gcpAccessToken.getClientSecret,
-            "google.cloud.auth.refresh.token"          -> gcpAccessToken.getRefreshToken
-          )
-
-       */
-      case "SERVICE_ACCOUNT_JSON_KEYFILE" =>
-        val jsonKeyFilename = connectionOptions.getOrElse(
-          "jsonKeyfile",
-          throw new Exception("jsonKeyfile attribute is required for SERVICE_ACCOUNT_JSON_KEYFILE")
-        )
-
-        val jsonKeyFile = BigQueryJobBase.getJsonKeyAbsoluteFile(jsonKeyFilename)
-        if (!jsonKeyFile.exists()) {
-          throw new Exception(s"jsonKeyfile $jsonKeyFilename does not exist")
-        }
-
-        Map(
-          "google.cloud.auth.type"                         -> "SERVICE_ACCOUNT_JSON_KEYFILE",
-          "google.cloud.auth.service.account.enable"       -> "true",
-          "google.cloud.auth.service.account.json.keyfile" -> jsonKeyFile.toString()
-        )
-      case "USER_CREDENTIALS" =>
-        val clientId = connectionOptions.getOrElse(
-          "clientId",
-          throw new Exception("clientId attribute is required for USER_CREDENTIALS")
-        )
-        val clientSecret = connectionOptions.getOrElse(
-          "clientSecret",
-          throw new Exception("clientSecret attribute is required for USER_CREDENTIALS")
-        )
-        val refreshToken = connectionOptions.getOrElse(
-          "refreshToken",
-          throw new Exception("refreshToken attribute is required for USER_CREDENTIALS")
-        )
-        Map(
-          "google.cloud.auth.type"                   -> "USER_CREDENTIALS",
-          "google.cloud.auth.service.account.enable" -> "true",
-          "google.cloud.auth.client.id"              -> clientId,
-          "google.cloud.auth.client.secret"          -> clientSecret,
-          "google.cloud.auth.refresh.token"          -> refreshToken
-        )
-      case _ =>
-        Map.empty[String, String]
-    }
-    authConf
-  }
 
   private def gcpExtraConf(connectionOptions: Map[String, String]): Map[String, String] = {
     val gcpOptions = connectionOptions.filter { case (k, _) => k.startsWith("google.cloud") }
@@ -136,7 +75,7 @@ class HdfsStorageHandler(fileSystem: String)(implicit
           "fs.gs.impl"                    -> "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem"
         )
       }
-    val authConf = gcpAuthConf(connectionOptions)
+    val authConf = GcpCredentials.hadoopAuthConf(connectionOptions)
     fsConfig ++ authConf ++ gcpOptions
   }
 

--- a/src/main/scala/ai/starlake/utils/GcpCredentials.scala
+++ b/src/main/scala/ai/starlake/utils/GcpCredentials.scala
@@ -1,7 +1,11 @@
 package ai.starlake.utils
 
 import ai.starlake.config.Settings
-import ai.starlake.job.sink.bigquery.BigQueryJobBase.{getJsonKeyStream, getJsonKeyStreamFromBase64}
+import ai.starlake.job.sink.bigquery.BigQueryJobBase.{
+  getJsonKeyAbsoluteFile,
+  getJsonKeyStream,
+  getJsonKeyStreamFromBase64
+}
 import com.google.auth.Credentials
 import com.google.auth.oauth2.{
   AccessToken,
@@ -71,5 +75,76 @@ object GcpCredentials extends LazyLogging {
             scala.Option(cred)
         }
     }
+  }
+
+  /** Maps a connection's `authType` (as declared in the YAML config) onto the google.cloud.auth.*
+    * Hadoop properties the GCS connector reads.
+    *
+    * gcs-connector defaults `google.cloud.auth.type` to COMPUTE_ENGINE, so any Hadoop configuration
+    * that does not carry these keys ends up querying the GCE metadata server, which only exists on
+    * Google infrastructure.
+    */
+  def hadoopAuthConf(
+    connectionOptions: Map[String, String]
+  )(implicit settings: Settings): Map[String, String] = {
+    val authType = connectionOptions.getOrElse("authType", "APPLICATION_DEFAULT")
+    val authConf = authType match {
+      case "APPLICATION_DEFAULT" =>
+        Map(
+          "google.cloud.auth.type" -> "APPLICATION_DEFAULT"
+        )
+      /*
+          val gcpAccessToken =
+            GcpUtils.getCredentialUsingWellKnownFile().asInstanceOf[UserCredentials]
+
+          Map(
+            "google.cloud.auth.type"                   -> "USER_CREDENTIALS",
+            "google.cloud.auth.service.account.enable" -> "true",
+            "google.cloud.auth.client.id"              -> gcpAccessToken.getClientId,
+            "google.cloud.auth.client.secret"          -> gcpAccessToken.getClientSecret,
+            "google.cloud.auth.refresh.token"          -> gcpAccessToken.getRefreshToken
+          )
+
+       */
+      case "SERVICE_ACCOUNT_JSON_KEYFILE" =>
+        val jsonKeyFilename = connectionOptions.getOrElse(
+          "jsonKeyfile",
+          throw new Exception("jsonKeyfile attribute is required for SERVICE_ACCOUNT_JSON_KEYFILE")
+        )
+
+        val jsonKeyFile = getJsonKeyAbsoluteFile(jsonKeyFilename)
+        if (!jsonKeyFile.exists()) {
+          throw new Exception(s"jsonKeyfile $jsonKeyFilename does not exist")
+        }
+
+        Map(
+          "google.cloud.auth.type"                         -> "SERVICE_ACCOUNT_JSON_KEYFILE",
+          "google.cloud.auth.service.account.enable"       -> "true",
+          "google.cloud.auth.service.account.json.keyfile" -> jsonKeyFile.toString()
+        )
+      case "USER_CREDENTIALS" =>
+        val clientId = connectionOptions.getOrElse(
+          "clientId",
+          throw new Exception("clientId attribute is required for USER_CREDENTIALS")
+        )
+        val clientSecret = connectionOptions.getOrElse(
+          "clientSecret",
+          throw new Exception("clientSecret attribute is required for USER_CREDENTIALS")
+        )
+        val refreshToken = connectionOptions.getOrElse(
+          "refreshToken",
+          throw new Exception("refreshToken attribute is required for USER_CREDENTIALS")
+        )
+        Map(
+          "google.cloud.auth.type"                   -> "USER_CREDENTIALS",
+          "google.cloud.auth.service.account.enable" -> "true",
+          "google.cloud.auth.client.id"              -> clientId,
+          "google.cloud.auth.client.secret"          -> clientSecret,
+          "google.cloud.auth.refresh.token"          -> refreshToken
+        )
+      case _ =>
+        Map.empty[String, String]
+    }
+    authConf
   }
 }

--- a/src/test/scala/ai/starlake/config/SparkEnvGcsAuthSpec.scala
+++ b/src/test/scala/ai/starlake/config/SparkEnvGcsAuthSpec.scala
@@ -1,0 +1,59 @@
+package ai.starlake.config
+
+import com.typesafe.config.{ConfigFactory, ConfigParseOptions}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** The GCS connector defaults google.cloud.auth.type to COMPUTE_ENGINE, so a Spark session
+  * that does not carry the connection's authType queries the GCE metadata server and fails
+  * anywhere outside Google infrastructure.
+  */
+class SparkEnvGcsAuthSpec extends AnyFlatSpec with Matchers {
+
+  private def settingsWith(connectionOptions: String): Settings = {
+    val root = java.nio.file.Files.createTempDirectory("sl-sparkenv-gcsauth").toString
+    val config = ConfigFactory.load(
+      ConfigFactory.parseString(
+        s"""
+           |SL_ROOT="$root"
+           |connectionRef: "bq"
+           |connections.bq {
+           |    type = "bigquery"
+           |    options {
+           |      "projectId": "test-project"
+           |$connectionOptions
+           |    }
+           |}
+           |""".stripMargin,
+        ConfigParseOptions.defaults().setAllowMissing(false)
+      )
+    )
+    Settings(config, None, None, None, None)
+  }
+
+  private def confFor(connectionOptions: String): Map[String, String] = {
+    implicit val settings: Settings = settingsWith(connectionOptions)
+    SparkEnv.bigQueryConf(settings.appConfig.connections("bq"))
+  }
+
+  "a BigQuery connection declaring authType" should "propagate it to the GCS connector" in {
+    val conf = confFor("""      "authType": "APPLICATION_DEFAULT"""")
+    conf("spark.hadoop.google.cloud.auth.type") shouldEqual "APPLICATION_DEFAULT"
+    conf("spark.hadoop.fs.gs.project.id") shouldEqual "test-project"
+    conf("parentProject") shouldEqual "test-project"
+  }
+
+  it should "propagate USER_CREDENTIALS and its secrets" in {
+    val conf = confFor("""      "authType": "USER_CREDENTIALS"
+                         |      "clientId": "id"
+                         |      "clientSecret": "secret"
+                         |      "refreshToken": "token"""".stripMargin)
+    conf("spark.hadoop.google.cloud.auth.type") shouldEqual "USER_CREDENTIALS"
+    conf("spark.hadoop.google.cloud.auth.client.id") shouldEqual "id"
+    conf("spark.hadoop.google.cloud.auth.refresh.token") shouldEqual "token"
+  }
+
+  "a BigQuery connection without authType" should "default to APPLICATION_DEFAULT" in {
+    confFor("")("spark.hadoop.google.cloud.auth.type") shouldEqual "APPLICATION_DEFAULT"
+  }
+}


### PR DESCRIPTION
Fixes the remaining 4 CI failures (`BigQueryBranchSpec` ×2, `SparkParquetToBigQuerySpec` ×2), the ones left out of #1738.

## Root cause

The tests fail as `false was not equal to true`, but the real error underneath is:

```
Caused by: java.io.IOException: Error accessing gs://***/.spark-bigquery-local-...
Caused by: java.io.IOException: ComputeEngineCredentials cannot find the metadata server.
Caused by: java.net.UnknownHostException: metadata.google.internal
```

gcs-connector 4.0.4, which arrived with the Spark 4 migration, defaults `google.cloud.auth.type` to `COMPUTE_ENGINE`. Verified by disassembling the shipped jar:

```
10: ldc_w  // String .auth.type
13: getstatic  // Field HadoopCredentialsConfiguration$AuthenticationType.COMPUTE_ENGINE
```

(The property prefix is still `google.cloud`, so the existing key names are correct.)

`SparkEnv` set only `spark.hadoop.fs.gs.project.id` on the session, never an auth type, so the connector reached for the GCE metadata server. On a GitHub runner that host does not resolve.

## Fix

The connection already declares `authType` in YAML, and `HdfsStorageHandler` already honoured it for its own Hadoop conf — the Spark session was simply not given it. So rather than hardcoding an auth type, this propagates what the connection declares:

- `gcpAuthConf` moves from `HdfsStorageHandler` (private) to `GcpCredentials.hadoopAuthConf`
- `SparkEnv` applies that map under the `spark.hadoop.` prefix
- behaviour is unchanged for every auth type: `APPLICATION_DEFAULT`, `SERVICE_ACCOUNT_JSON_KEYFILE`, `USER_CREDENTIALS`, defaulting to `APPLICATION_DEFAULT` exactly as `HdfsStorageHandler` did

This is why no workflow change is needed: `application-test.conf` already declares `authType: APPLICATION_DEFAULT` on both BigQuery connections, and the workflow already exports credentials via `google-github-actions/auth`. The value simply never reached the Spark session.

It also fixes the same class of failure for real users running Spark against GCS off Google infrastructure, which is the general case, not just CI.

## Verification

The BigQuery config assembly is extracted into `SparkEnv.bigQueryConf` so it can be asserted without starting a Spark session. New `SparkEnvGcsAuthSpec` covers the propagation:

```
[info] Tests: succeeded 3, failed 0, canceled 0, ignored 0, pending 0
```

- `authType: APPLICATION_DEFAULT` → `spark.hadoop.google.cloud.auth.type = APPLICATION_DEFAULT`
- `authType: USER_CREDENTIALS` → type plus client id / refresh token propagated
- no `authType` → defaults to `APPLICATION_DEFAULT`

What I could **not** verify locally is the end-to-end BigQuery path, which needs live GCP credentials. The four BigQuery specs will be the real proof when CI runs this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)