### PR TITLE
fix: escape SQL string literals consistently in audit and expectations sinks

### DIFF
--- a/src/main/scala/ai/starlake/job/ingest/AuditLog.scala
+++ b/src/main/scala/ai/starlake/job/ingest/AuditLog.scala
@@ -111,7 +111,7 @@ case class AuditLog(
     val selectStatement = template.richFormat(
       Map(
         "jobid"         -> escapeLiteral(jobid),
-        "paths"         -> paths.map(escapeLiteral).getOrElse("null"),
+        "paths"         -> paths.map(escapeLiteral(_)).getOrElse("null"),
         "domain"        -> escapeLiteral(domain),
         "schema"        -> escapeLiteral(schema),
         "success"       -> success,

--- a/src/main/scala/ai/starlake/job/ingest/AuditTaskBuilder.scala
+++ b/src/main/scala/ai/starlake/job/ingest/AuditTaskBuilder.scala
@@ -60,10 +60,19 @@ object AuditTaskBuilder {
     * line carrying the first still aborted the whole load, which is precisely what the caller uses
     * this for. Removing every brace can neither leave a delimiter nor build one, and applying it
     * twice changes nothing, so please do not "improve" it back into pairwise stripping.
+    *
+    * @param quoteReplacement
+    *   What a single quote becomes. Defaults to a dash, which is what every caller that inlines a
+    *   value into a quoted SQL literal wants. A caller that inlines SQL text of its own, such as
+    *   the expectations sink, wants that text to stay readable and passes a value that stays safe
+    *   inside the enclosing single quoted literal instead, for example a double quote. The fixpoint
+    *   argument above only holds if `quoteReplacement` itself contains no quote, backslash or
+    *   brace, since it is not run back through this method; every call site in this codebase passes
+    *   a literal constant, so that is a review-time invariant, not a runtime check.
     */
-  def escapeLiteral(value: String): String =
+  def escapeLiteral(value: String, quoteReplacement: String = "-"): String =
     value
-      .replaceAll("'", "-")
+      .replaceAll("'", quoteReplacement)
       .replaceAll("\\\\", "-")
       .replaceAll("\\n", " ")
       .replaceAll("[{}]", "")

--- a/src/main/scala/ai/starlake/job/ingest/AuditTaskBuilder.scala
+++ b/src/main/scala/ai/starlake/job/ingest/AuditTaskBuilder.scala
@@ -48,31 +48,33 @@ object AuditTaskBuilder {
     * `Jinjava.render` throws on it, which would fail the whole job over a single value. Shared by
     * every caller of `buildTask` so the escapings cannot drift apart.
     *
-    * The invariant is that the result contains no quote, no backslash and no brace at all, so no
-    * Jinja delimiter can survive the escaping and none can be assembled out of what does. Every
-    * Jinja delimiter needs a brace (`{{ }}`, `{% %}`, `{# #}`), and it also means the result is
-    * immune to the `{{key}}` substitution `Formatter.richFormat` runs over the same template. This
-    * is why the braces go wholesale and not pairwise. Stripping the six delimiters as pairs looks
-    * tighter but is not a fixpoint: each `replaceAll` pass is non overlapping and left to right, so
-    * a deletion joins the characters on either side of it and the join is never rescanned, which
-    * lets the escaping SYNTHESIZE a live delimiter out of an input that carried none. Pairwise
-    * stripping turned `{}}%ANUM%#}}` into `{%ANUM%}` and `{}}{ANUM}%}}` into `{{ANUM}}`, so a DSV
-    * line carrying the first still aborted the whole load, which is precisely what the caller uses
-    * this for. Removing every brace can neither leave a delimiter nor build one, and applying it
-    * twice changes nothing, so please do not "improve" it back into pairwise stripping.
+    * The invariant is that the result contains no single quote (given a `quoteReplacement` that
+    * carries none itself), no backslash and no brace at all, so no Jinja delimiter can survive the
+    * escaping and none can be assembled out of what does. Every Jinja delimiter needs a brace (`{{
+    * }}`, `{% %}`, `{# #}`), and it also means the result is immune to the `{{key}}` substitution
+    * `Formatter.richFormat` runs over the same template. This is why the braces go wholesale and
+    * not pairwise. Stripping the six delimiters as pairs looks tighter but is not a fixpoint: each
+    * `replaceAll` pass is non overlapping and left to right, so a deletion joins the characters on
+    * either side of it and the join is never rescanned, which lets the escaping SYNTHESIZE a live
+    * delimiter out of an input that carried none. Pairwise stripping turned `{}}%ANUM%#}}` into
+    * `{%ANUM%}` and `{}}{ANUM}%}}` into `{{ANUM}}`, so a DSV line carrying the first still aborted
+    * the whole load, which is precisely what the caller uses this for. Removing every brace can
+    * neither leave a delimiter nor build one, and applying it twice changes nothing, so please do
+    * not "improve" it back into pairwise stripping.
     *
     * @param quoteReplacement
     *   What a single quote becomes. Defaults to a dash, which is what every caller that inlines a
     *   value into a quoted SQL literal wants. A caller that inlines SQL text of its own, such as
     *   the expectations sink, wants that text to stay readable and passes a value that stays safe
-    *   inside the enclosing single quoted literal instead, for example a double quote. The fixpoint
-    *   argument above only holds if `quoteReplacement` itself contains no quote, backslash or
-    *   brace, since it is not run back through this method; every call site in this codebase passes
-    *   a literal constant, so that is a review-time invariant, not a runtime check.
+    *   inside the enclosing single quoted literal instead, for example a double quote. The value is
+    *   inserted literally (`Matcher.quoteReplacement` neutralizes the `$` and `\` regex replacement
+    *   metacharacters), and a replacement carrying a brace or backslash is cleaned up by the later
+    *   passes, so the one thing a caller must never pass is a single quote, which no later pass
+    *   removes and which would reopen the enclosing literal.
     */
   def escapeLiteral(value: String, quoteReplacement: String = "-"): String =
     value
-      .replaceAll("'", quoteReplacement)
+      .replaceAll("'", java.util.regex.Matcher.quoteReplacement(quoteReplacement))
       .replaceAll("\\\\", "-")
       .replaceAll("\\n", " ")
       .replaceAll("[{}]", "")

--- a/src/main/scala/ai/starlake/job/metrics/ExpectationJob.scala
+++ b/src/main/scala/ai/starlake/job/metrics/ExpectationJob.scala
@@ -53,22 +53,26 @@ case class ExpectationReport(
 
   def asSelect(engineName: Engine)(implicit settings: Settings): String = {
     import ai.starlake.utils.Formatter.*
+    import ai.starlake.job.ingest.AuditTaskBuilder.escapeLiteral
     timestamp.setNanos(0)
     val template = ExpectationJob.selectTemplate(engineName)
-    def replaceQuote(s: String): String =
-      s.replaceAll("'", "\"").replaceAll("\n", " ").replaceAll("\\{\\{", "").replaceAll("}}", "")
+    // name, params, sql and exception record free form text, including SQL, which is full of
+    // single quotes. Passing a double quote as the replacement keeps that text readable, unlike
+    // the default dash every other field below uses, and stays safe inside the single quoted
+    // literal the template wraps each value in.
+    def escapeText(s: String): String = escapeLiteral(s, "\"")
     val mapParam =
       Map(
-        "jobid"     -> jobId,
-        "database"  -> database.getOrElse(""),
-        "domain"    -> domain,
-        "schema"    -> schema,
+        "jobid"     -> escapeLiteral(jobId),
+        "database"  -> escapeLiteral(database.getOrElse("")),
+        "domain"    -> escapeLiteral(domain),
+        "schema"    -> escapeLiteral(schema),
         "timestamp" -> timestamp.toString(),
-        "name"      -> replaceQuote(name),
-        "params"    -> replaceQuote(params),
-        "sql"       -> replaceQuote(sql.getOrElse("")),
+        "name"      -> escapeText(name),
+        "params"    -> escapeText(params),
+        "sql"       -> escapeText(sql.getOrElse("")),
         "count"     -> count.getOrElse(0L).toString,
-        "exception" -> replaceQuote(exception.getOrElse("")),
+        "exception" -> escapeText(exception.getOrElse("")),
         "success"   -> success.toString
       )
     val selectStatement = template.richFormat(mapParam, Map.empty)

--- a/src/test/scala/ai/starlake/job/ingest/AuditTaskBuilderSpec.scala
+++ b/src/test/scala/ai/starlake/job/ingest/AuditTaskBuilderSpec.scala
@@ -46,6 +46,13 @@ class AuditTaskBuilderSpec extends AnyFlatSpec {
     escaped shouldBe "a-b c"
   }
 
+  it should "insert the replacement literally, not as a regex replacement string" in {
+    // replaceAll's second argument treats $ and \ as metacharacters; Matcher.quoteReplacement
+    // makes the parameter literal so a $ bearing replacement cannot throw from the audit path.
+    AuditTaskBuilder.escapeLiteral("a'b", "$1") shouldBe "a$1b"
+    AuditTaskBuilder.escapeLiteral("a'b", "$") shouldBe "a$b"
+  }
+
   "escapeLiteral called with one argument" should
   "produce exactly what it produced before the second parameter was added" in {
     // pinned example: quote becomes a dash, backslash becomes a dash, newline becomes a

--- a/src/test/scala/ai/starlake/job/ingest/AuditTaskBuilderSpec.scala
+++ b/src/test/scala/ai/starlake/job/ingest/AuditTaskBuilderSpec.scala
@@ -1,0 +1,56 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ *
+ */
+
+package ai.starlake.job.ingest
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
+class AuditTaskBuilderSpec extends AnyFlatSpec {
+
+  "escapeLiteral with a custom quote replacement" should
+  "replace the quote with the given replacement while leaving the other passes untouched" in {
+    val escaped = AuditTaskBuilder.escapeLiteral("it's a 'test'", "\"")
+    escaped shouldBe "it\"s a \"test\""
+  }
+
+  it should "still drop every brace, including one that would synthesize a delimiter" in {
+    // pairwise stripping of {{ }} / {% %} / {# #} is not a fixpoint: it can join what is left
+    // of two different pairs into a live delimiter. Removing every brace, one at a time,
+    // cannot do that, whatever quoteReplacement is.
+    val escaped = AuditTaskBuilder.escapeLiteral("{}}%ANUM%#}}", "\"")
+    escaped shouldBe "%ANUM%#"
+    escaped should not include "{"
+    escaped should not include "}"
+  }
+
+  it should "still neutralize backslashes and newlines" in {
+    val escaped = AuditTaskBuilder.escapeLiteral("a\\b\nc", "\"")
+    escaped shouldBe "a-b c"
+  }
+
+  "escapeLiteral called with one argument" should
+  "produce exactly what it produced before the second parameter was added" in {
+    // pinned example: quote becomes a dash, backslash becomes a dash, newline becomes a
+    // space, every brace is gone.
+    AuditTaskBuilder.escapeLiteral("it's a {{value}} with a \\ and a\nnewline") shouldBe
+    "it-s a value with a - and a newline"
+  }
+}

--- a/src/test/scala/ai/starlake/job/metrics/ExpectationReportSpec.scala
+++ b/src/test/scala/ai/starlake/job/metrics/ExpectationReportSpec.scala
@@ -1,0 +1,55 @@
+package ai.starlake.job.metrics
+
+import ai.starlake.TestHelper
+import ai.starlake.schema.model.Engine
+
+import java.sql.Timestamp
+import java.time.Instant
+
+class ExpectationReportSpec extends TestHelper {
+
+  new WithSettings() {
+
+    "ExpectationReport.asSelect" should
+    "escape quotes, jinja delimiters and backslashes without failing the Jinja pass" in {
+      val report = ExpectationReport(
+        jobId = "job'1",
+        database = Some("db'name"),
+        domain = "dom'ain",
+        schema = "sch'ema",
+        timestamp = Timestamp.from(Instant.now()),
+        name = "it's a name with a trailing \\",
+        params = "params {% ANUM %} end",
+        sql = Some("SELECT 1 {# comment #}"),
+        count = Some(1L),
+        // {}}%ANUM%#}} carries no delimiter of its own: pairwise stripping of {{ }} / {% %} /
+        // {# #} is not a fixpoint and used to synthesize {%ANUM%} out of it, which is exactly
+        // the kind of value this field records (a rendered exception message can contain
+        // anything the failing SQL engine echoed back).
+        exception = Some("boom {}}%ANUM%#}} end"),
+        success = false
+      )
+
+      val select = report.asSelect(Engine.JDBC)
+
+      // name and exception went through the local replaceQuote before this change; params and
+      // sql exercise the {% %} and {# #} delimiters that replaceQuote never stripped at all.
+      select should include("it\"s a name with a trailing -")
+      select should include("params % ANUM % end")
+      select should include("SELECT 1 # comment #")
+      select should include("boom %ANUM%# end")
+
+      // jobid, database, domain and schema used to be inlined raw; they now go through the
+      // default (one argument) escapeLiteral, so a quote in any of them becomes a dash, not a
+      // double quote.
+      select should include("job-1")
+      select should include("db-name")
+      select should include("dom-ain")
+      select should include("sch-ema")
+
+      select should not include "{"
+      select should not include "}"
+      select should not include "\\"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Share the audit SQL literal escaping logic with the expectations sink, so both sinks escape string values the same way (`AuditTaskBuilder` is now the single source of truth).
- Insert the quote replacement literally via `Matcher.quoteReplacement`, so `$` and backslashes in values no longer corrupt the generated SQL; the caller invariant shrinks to the single real one: no unescaped single quote.

## Tests
- New `AuditTaskBuilderSpec` covering the escaping helper, including `$`/backslash payloads.
- New `ExpectationReportSpec` covering the expectations sink using the shared escaping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7nDBiBJ6sPcqrkzp1pBg