### PR TITLE
test: make TransformIntegrationBQSpec provision its own fixtures

### DIFF
--- a/src/test/scala/ai/starlake/integration/transform/TransformIntegrationBQSpec.scala
+++ b/src/test/scala/ai/starlake/integration/transform/TransformIntegrationBQSpec.scala
@@ -2,16 +2,61 @@ package ai.starlake.integration.transform
 
 import ai.starlake.integration.BigQueryIntegrationSpecBase
 import ai.starlake.job.Main
+import com.google.cloud.bigquery.{DatasetInfo, QueryJobConfiguration, TableId}
 
 class TransformIntegrationBQSpec extends BigQueryIntegrationSpecBase {
-  override def beforeAll(): Unit = {}
+
+  /** The transform's source tables, provisioned directly so the transform test does not depend on
+    * the load test having populated them: CI showed sales.customers can be missing when the
+    * transform starts, which fails it with "Table not found". Tables are only created when absent,
+    * so a real load's output is left untouched, and a later full run starts from the base class's
+    * clean slate anyway.
+    */
+  /** Everything in this test lives in europe-west1 (application.sl.yml); the materialization
+    * dataset has to be there too, because the connector runs the transform's query in the
+    * materialization dataset's location and cannot see sales from anywhere else.
+    */
+  private val materializationDataset = "SL_BQ_TEST_DS"
+
+  private def ensureDataset(name: String): Unit =
+    if (bigquery.getDataset(name) == null)
+      bigquery.create(DatasetInfo.newBuilder(name).setLocation("europe-west1").build())
+
+  private def provisionTransformSources(): Unit = {
+    ensureDataset(materializationDataset)
+    ensureDataset("sales")
+    def ensure(table: String, createSql: String, seedSql: String): Unit =
+      if (bigquery.getTable(TableId.of("sales", table)) == null) {
+        bigquery.query(QueryJobConfiguration.newBuilder(createSql).build())
+        bigquery.query(QueryJobConfiguration.newBuilder(seedSql).build())
+      }
+    ensure(
+      "customers",
+      "CREATE TABLE sales.customers(id STRING, signup TIMESTAMP, contact STRING, " +
+      "birthdate DATE, name1 STRING, name2 STRING, id1 STRING)",
+      "INSERT INTO sales.customers(id, name1) VALUES ('A009701', 'fixture'), ('B308629', 'fixture')"
+    )
+    // amount is NUMERIC, not FLOAT64: the loaded schema types it as decimal, and the transform's
+    // sum(amount) has to append into the existing byseller_kpi target whose sum column is NUMERIC
+    ensure(
+      "orders",
+      "CREATE TABLE sales.orders(id STRING, customer_id STRING, amount NUMERIC, " +
+      "seller_id STRING, ts TIMESTAMP)",
+      "INSERT INTO sales.orders(id, customer_id, amount) " +
+      "VALUES ('O1', 'A009701', 10.5), ('O2', 'B308629', 20.0)"
+    )
+  }
 
   "Native Bigquery Load" should "succeed" in {
     if (sys.env.getOrElse("SL_REMOTE_TEST", "false").toBoolean) {
       withEnvs(
         "SL_ENV"                                        -> "BQ",
         "SL_SPARK_SQL_SOURCES_PARTITION_OVERWRITE_MODE" -> "DYNAMIC",
-        "SL_ROOT"                                       -> theSampleFolder.pathAsString
+        // set on the load test too: the Spark session is built once per JVM, during this test,
+        // and the materialization dataset is baked into its conf, so setting it only on the
+        // transform test would come too late
+        "SL_SPARK_BIGQUERY_MATERIALIZATION_DATASET" -> materializationDataset,
+        "SL_ROOT"                                   -> theSampleFolder.pathAsString
       ) {
         cleanup()
         copyFilesToIncomingDir(sampleDataDir)
@@ -30,9 +75,11 @@ class TransformIntegrationBQSpec extends BigQueryIntegrationSpecBase {
   }
   "Native Bigquery Transform" should "succeed" in {
     if (sys.env.getOrElse("SL_REMOTE_TEST", "false").toBoolean) {
+      provisionTransformSources()
       withEnvs(
         "SL_ENV"                                        -> "BQ",
         "SL_SPARK_SQL_SOURCES_PARTITION_OVERWRITE_MODE" -> "DYNAMIC",
+        "SL_SPARK_BIGQUERY_MATERIALIZATION_DATASET"     -> materializationDataset,
         "SL_ROOT"                                       -> theSampleFolder.pathAsString
       ) {
         assert(


### PR DESCRIPTION
## Summary
The transform test failed in CI with `Not found: Table sales.customers` whenever its source tables were missing when it started: it silently depended on the load test's output (the spec even overrode the base class's clean-slate `beforeAll` to keep that coupling alive).

The spec now provisions everything it needs:
- The base `beforeAll` clean slate is restored.
- The transform test creates the `sales` dataset and schema-faithful `customers`/`orders` tables when absent (`amount NUMERIC`, matching the loaded decimal type and the existing `byseller_kpi` target), leaving a real load's output untouched.
- It provisions the materialization dataset (`SL_BQ_TEST_DS`, europe-west1) and passes it via `SL_SPARK_BIGQUERY_MATERIALIZATION_DATASET` on **both** tests: the Spark session is built once per JVM during the load test and bakes the setting into its conf, and the default `BQ_TEST_DS` may live in another location (US in the local project), which fails the transform's query with `Dataset sales was not found in location US`.

## Verification (SL_REMOTE_TEST=true, live BigQuery)
- Transform test standalone with tables absent: reproduced the CI failure first, green after the fix (21s).
- Full suite (real load then transform): both green (2m57s + 15s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7nDBiBJ6sPcqrkzp1pBg