### PR TITLE
chore: jsqltranspiler 1.11 and its pinned jsqlparser 5.3.336

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -229,9 +229,8 @@ object Dependencies {
 
   // com.manticore-projects.jsqlformatter
   def jSqlTranspiler(isSnapshot: Boolean) = {
-    // 1.8.0 deliberately ships against the pinned jsqltranspiler/jsqlparser versions verbatim,
-    // SNAPSHOT or not (user decision at release time); the old release-strip behavior demanded
-    // a released artifact that does not exist yet. Restore stripping once jsqltranspiler 1.11 ships.
+    // jsqltranspiler 1.11 and the jsqlparser it pins are plain releases now, so the pinned
+    // versions ship verbatim and the old release-strip behavior has nothing left to strip.
     val jSqlTranspilerVersion = Versions.jSqlTranspiler
     val starlakeJdbcVersion = Versions.starlakejdbc
     Seq(

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -55,9 +55,9 @@ object Versions {
   val scalaParallelCollections = "1.2.0" // matches Spark 4.1.3
   val derbyVersion =
     "10.15.2.0" // last version compatible with Java 11, see https://db.apache.org/derby/derby_downloads.html
-  // jSqlParser must match the version jsqltranspiler's pom pins (its manticore snapshot line)
-  val jSqlParser = "5.4.260-SNAPSHOT"
-  val jSqlTranspiler = "1.11-SNAPSHOT"
+  // jSqlParser must match the version jsqltranspiler's pom pins
+  val jSqlParser = "5.3.336"
+  val jSqlTranspiler = "1.11"
   val starlakejdbc = "0.7"
   val airflowTemplates = "0.6.15"
   val jSqlFormatter = "5.4.1"


### PR DESCRIPTION
## Summary
jsqltranspiler 1.11 is now released on Maven Central, so the snapshot coupling ends:

- `jSqlTranspiler`: 1.11-SNAPSHOT → **1.11**
- `jSqlParser`: 5.4.260-SNAPSHOT → **5.3.336**, the released version 1.11's pom pins (the coupling rule in Versions.scala is unchanged: jsqlparser must match jsqltranspiler's pin)
- Retires the 'restore stripping once jsqltranspiler 1.11 ships' note in Dependencies.scala: both pins are plain releases shipped verbatim, nothing left to strip.

This also obsoletes steward PR #1749 (jsqlparser 5.4.336-SNAPSHOT), which proposed a version the transpiler does not pin.

## Verification
`sbt compile` plus the transpiler and SQL parsing suites: `TranspileDialectAppConfigSpec`, `ColLineageIntegrationSpec`, `StarlakeTestsFrameworkSpec`, `SQLUtilsSpec` — 40/40 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7nDBiBJ6sPcqrkzp1pBg