### PR TITLE
chore: apply the tier-2 dependency bumps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,9 +80,9 @@ dependencyOverrides := Seq(
   // fully shade/relocate their own protobuf-java, so raising this override does not affect
   // GCS batch requests (an earlier 4.33.2 regression report was collateral eviction churn,
   // not a protobuf conflict through this path). google-cloud-datacatalog 1.101.0's own gencode
-  // is stamped 4.33.6, raising the runtime floor accordingly; 4.35.1 is the latest stable 4.x
-  // release satisfying that floor (avoid 4.36.0-RC, a pre-release).
-  "com.google.protobuf"                % "protobuf-java"             % "4.35.1",
+  // is stamped 4.33.6, raising the runtime floor accordingly; 4.36.1 is the latest stable 4.x
+  // release satisfying that floor.
+  "com.google.protobuf"                % "protobuf-java"             % "4.36.1",
   "org.scala-lang"                    % "scala-library"             % scalaVersion.value,
   "org.scala-lang"                    % "scala-reflect"             % scalaVersion.value,
   "org.scala-lang"                    % "scala-compiler"            % scalaVersion.value,

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,6 +1,6 @@
 object Versions {
   val spark4 = "4.1.3"
-  val deltaSpark = "4.3.1" // artifact id is delta-spark_4.1
+  val deltaSpark = "4.4.0" // artifact id is delta-spark_4.1
   val scalatest = "3.2.19"
   // scalacheck-1-18 has no 3.2.20.0 on Maven Central (3.2.19.0 is the last of its line),
   // so scalatest is held at 3.2.19 to move together with it.
@@ -34,18 +34,18 @@ object Versions {
   // so the regression is inside the google-cloud-bigquery 2.69.0 artifact itself, not a
   // transitive dependency clash. See .superpowers/sdd/recipeb-report.md for the full bisect.
   val bigquery = "2.68.0"
-  val gcsConnector = "4.0.4" // new versioning scheme, built against Hadoop 3.4.2
+  val gcsConnector = "4.0.5" // new versioning scheme, built against Hadoop 3.4.2
   val hadoop = "3.4.2" // must match Spark 4.1.3's Hadoop line; aws/azure artifacts use this too
   val awsSdkBundle = "2.29.52" // software.amazon.awssdk (v2), pinned by hadoop-project 3.4.2
-  val sparkBigquery = "0.44.2-preview" // artifact spark-4.1-bigquery, no scala suffix, GA build not yet published for 4.1
+  val sparkBigquery = "0.45.0" // artifact spark-4.1-bigquery, no scala suffix, first GA build for 4.1
   val bigqueryConnector = "hadoop3-1.2.0"
   val h2 = "2.5.250" // Test only
   val poi = "4.1.2"
-  val confluentVersion = "7.7.11"
-  val kafkaClients = "7.7.11-ce"
+  val confluentVersion = "7.9.3"
+  val kafkaClients = "7.9.3-ce"
   val testContainers = "0.44.1"
-  val gcpCloudLogging = "3.36.0"
-  val gcpDataCatalog = "1.101.0"
+  val gcpCloudLogging = "3.38.0"
+  val gcpDataCatalog = "1.102.0"
   val jinja = "2.7.4" // forces dependency override on guava
   val snowflakeJDBC = "4.3.4" // spark-snowflake 3.2.x requires >= 4.0.2
   val snowflakeSpark: String = "3.2.2-spark_4.1"

--- a/src/main/scala/ai/starlake/utils/GcpUtils.scala
+++ b/src/main/scala/ai/starlake/utils/GcpUtils.scala
@@ -6,7 +6,7 @@ import better.files.File
 // gcs-connector's shaded jar vendors com.google.cloud.logging.* unrelocated (it wins classpath
 // precedence over the real google-cloud-logging artifact), but relocates its own MonitoredResource
 // dependency to this repackaged path; the two must match or LogEntry.Builder#setResource won't compile.
-import com.google.cloud.hadoop.repackaged.gcs.com.google.cloud.MonitoredResource
+import com.google.cloud.MonitoredResource
 import com.google.cloud.logging.Payload.JsonPayload
 import com.google.cloud.logging.{LogEntry, LoggingException, LoggingOptions}
 import com.google.common.base.VerifyException


### PR DESCRIPTION
## Summary
The second round of steward-bump verifications (first round: #1756). Each bump either got its own local verification against live GCP, or is verified by this PR's snapshot CI run:

| Bump | Verification |
|---|---|
| kafka/confluent 7.9.3 (#1462/#1464) | KafkaJobSpec, 18/18 with testcontainers |
| delta-spark_4.1 4.4.0 (#1711) | delta-backed handler suites, 20/20 |
| google-cloud-logging 3.38.0 (#1746) | live GCPLOG smoke green |
| gcs-connector 4.0.5 (#1730) | live BigQuery + GCPLOG suites; **exposed a real bug**: `GcpUtils` imported the connector's *repackaged* `MonitoredResource` instead of the genuine `com.google.cloud` one (wrong-but-lucky under 4.0.4, a compile error under 4.0.5) — fixed here |
| spark-4.1-bigquery 0.45.0 (#1707) | first GA (non-preview) build for the 4.1 line; this PR's snapshot run |
| protobuf-java 4.36.1 (#1747) | the 4.35.1 pin only avoided 4.36.0 because it was an RC; 4.36.1 is stable, above the 4.33.6 gencode floor; this PR's snapshot run |
| google-cloud-datacatalog 1.102.0 (#1728) | this PR's snapshot run |

Also resolved outside this PR: #1473 closed (scala-collection-compat removed from the build), #1708 closed (guava pinned to Spark 4.1.3's version).

**Not included**: google-cloud-bigquery 2.71.0 (#1745) — still capped at 2.68.0; re-testing the 2.69.0 hang needs a solo, timeout-bounded run, not a CI job that would wedge.

If the snapshot run flags one of the CI-verified bumps, it gets dropped from this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7nDBiBJ6sPcqrkzp1pBg