### PR TITLE
ci: remove the Codecov upload from the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,18 +52,9 @@ jobs:
       - name: Use gcloud CLI
         if: ${{ github.event_name != 'pull_request' || github.event.action == 'ready_for_review' }}
         run: gcloud info
-      - name: Run tests & Coverage Report On Push
+      - name: Run tests On Push
         if: ${{ github.event_name != 'pull_request' }}
-        run: SBT_OPTS="-Xss4M -Xms1g -Xmx4g" SL_SPARK_BIGQUERY_MATERIALIZATION_DATASET=SL_BQ_TEST_DS SL_ACCESS_POLICIES_PROJECT_ID=${{ env.GCP_PROJECT }} TEMPORARY_GCS_BUCKET=${{ env.TEMPORARY_GCS_BUCKET }} SL_REMOTE_TEST=true GITHUB_TOKEN=${{ env.GITHUB_TOKEN }} sbt ++2.13.14! coverage coverageReport
-
-      - name: Upload coverage to Codecov
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: codecov/codecov-action@v1
-        with:
-          file: target/scala-2.13/scoverage-report/scoverage.xml
-          flags: unittests
-          fail_ci_if_error: true
-          verbose: true
+        run: SBT_OPTS="-Xss4M -Xms1g -Xmx4g" SL_SPARK_BIGQUERY_MATERIALIZATION_DATASET=SL_BQ_TEST_DS SL_ACCESS_POLICIES_PROJECT_ID=${{ env.GCP_PROJECT }} TEMPORARY_GCS_BUCKET=${{ env.TEMPORARY_GCS_BUCKET }} SL_REMOTE_TEST=true GITHUB_TOKEN=${{ env.GITHUB_TOKEN }} sbt ++2.13.14! test
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Removes the `codecov/codecov-action` step from `build.yml` and, since the only consumer of the scoverage report is gone, switches the test step from `coverage coverageReport` back to plain `sbt test` (also dropping the instrumentation overhead). No other workflow or file references Codecov; YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7nDBiBJ6sPcqrkzp1pBg