### PR TITLE
docs: point the build badge at test-only and fix the stale repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h3 align="center">Declarative Data Pipelines. Extract. Load. Transform. Orchestrate.</h3>
 
 <p align="center">
-  <a href="https://github.com/starlake-ai/starlake/workflows/Build/badge.svg"><img src="https://github.com/starlake-ai/starlake/workflows/Build/badge.svg" alt="Build Status"/></a>
-  <a href="https://github.com/starlake-ai/starlake/releases/latest"><img src="https://img.shields.io/github/v/release/starlake-ai/starlake" alt="GitHub Release"/></a>
+  <a href="https://github.com/starlake-ai/starflow/actions/workflows/test-only.yml"><img src="https://github.com/starlake-ai/starflow/actions/workflows/test-only.yml/badge.svg?event=pull_request" alt="Build Status"/></a>
+  <a href="https://github.com/starlake-ai/starflow/releases/latest"><img src="https://img.shields.io/github/v/release/starlake-ai/starflow" alt="GitHub Release"/></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"/></a>
 </p>
 
@@ -43,7 +43,7 @@ bash <(curl -sL https://starlake.ai/setup.sh)
 
 **Windows (PowerShell):**
 ```powershell
-Invoke-Expression (Invoke-WebRequest -Uri "https://raw.githubusercontent.com/starlake-ai/starlake/master/distrib/setup.ps1" -UseBasicParsing).Content
+Invoke-Expression (Invoke-WebRequest -Uri "https://raw.githubusercontent.com/starlake-ai/starflow/master/distrib/setup.ps1" -UseBasicParsing).Content
 ```
 
 **Docker:**


### PR DESCRIPTION
- Build badge now follows **test-only** (the full test suite gating every PR), scoped with `?event=pull_request` since that workflow has no push trigger — the old badge followed `Build`, a manual-dispatch-only workflow, on the pre-rename slug (years-stale status). Badge URL verified live (HTTP 200).
- Release shield and the raw `setup.ps1` URL move to the `starflow` slug.
- `starlake-data-stack` and `starlake-skills` links untouched: separate repos, not renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7nDBiBJ6sPcqrkzp1pBg