### PR TITLE
docs: restructure the README around a 30-second pipeline, Starflow-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,71 @@
 <p align="center">
-  <img src="docs/static/img/starlake-draw.png" alt="Starlake" width="600"/>
+  <img src="docs/static/img/starlake-draw.png" alt="Starflow" width="600"/>
 </p>
 
-<h3 align="center">Declarative Data Pipelines. Extract. Load. Transform. Orchestrate.</h3>
+<h1 align="center">Starflow</h1>
+<h3 align="center">Declarative data pipelines by Starlake: Extract. Load. Transform. Orchestrate.</h3>
 
 <p align="center">
   <a href="https://github.com/starlake-ai/starflow/actions/workflows/test-only.yml"><img src="https://github.com/starlake-ai/starflow/actions/workflows/test-only.yml/badge.svg?event=pull_request" alt="Build Status"/></a>
   <a href="https://github.com/starlake-ai/starflow/releases/latest"><img src="https://img.shields.io/github/v/release/starlake-ai/starflow" alt="GitHub Release"/></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"/></a>
+  <a href="https://github.com/starlake-ai/starflow/stargazers"><img src="https://img.shields.io/github/stars/starlake-ai/starflow" alt="GitHub Stars"/></a>
+  <a href="https://discord.com/invite/6tNa7yCNqw"><img src="https://img.shields.io/badge/Discord-join%20us-5865F2?logo=discord&logoColor=white" alt="Discord"/></a>
 </p>
 
 <p align="center">
   <a href="https://docs.starlake.ai/">Documentation</a> &bull;
   <a href="https://docs.starlake.ai/setup/starlake-core-setup">Installation</a> &bull;
+  <a href="https://discord.com/invite/6tNa7yCNqw">Discord</a> &bull;
   <a href="https://github.com/starlake-ai/starlake-data-stack">Data Stacks</a> &bull;
   <a href="https://docs.starlake.ai/devguide/contribute">Contributing</a>
 </p>
 
 ---
 
-Starlake replaces hundreds of lines of BigQuery/Snowflake/Redshift/Spark/SQL boilerplate with simple YAML declarations. Define **what** your data pipeline should do — Starlake figures out **how**.
+**Your warehouse, described, not scripted.** Starflow turns hundreds of lines of BigQuery/Snowflake/Redshift/Spark boilerplate into a few lines of YAML: declare **what** your pipeline does, and Starflow works out **how**: schemas, merges, quality checks, lineage, and the DAGs to run it all.
 
-Inspired by Terraform and Ansible, Starlake brings declarative programming to data engineering: schema inference, merge strategies, data quality checks, lineage tracking, and DAG generation — all from configuration files.
+## A pipeline in 30 seconds
 
-## Why Starlake?
+Describe the table once: file pattern, merge strategy, validation:
 
-- **No code, just config** - YAML declarations replace custom ETL scripts
-- **Any warehouse** - BigQuery, Snowflake, Redshift, DuckDB, PostgreSQL, Delta Lake, Iceberg
-- **Any orchestrator** - Airflow, Dagster, Snowflake Tasks with auto-generated DAGs
-- **Any source** - JDBC databases, CSV, JSON, XML, fixed-width, Parquet, Kafka
-- **Schema inference** - Auto-detect formats, headers, separators, and data types
-- **Built-in data quality** - Expectations and validation at load time
-- **Data lineage** - Automatic dependency tracking across your entire pipeline
-- **Privacy controls** - Column-level encryption and access policies
+```yaml
+# metadata/load/crm/customers.sl.yml
+table:
+  pattern: "customers.*.csv"              # files landing in your incoming folder
+  metadata:
+    writeStrategy:
+      type: UPSERT_BY_KEY_AND_TIMESTAMP   # incremental merge, no MERGE SQL to write
+      key: [id]
+      timestamp: signup
+  attributes:
+    - name: id
+      type: string
+      required: true
+    - name: signup
+      type: timestamp
+    - name: email
+      type: string                        # or one of your own semantic types, validated at load time
+```
+
+Then let Starflow do the engineering:
+
+```bash
+starlake bootstrap                        # scaffold a project
+starlake load                             # infer, validate and merge into your warehouse
+starlake transform --name kpi.revenue     # run SQL with the right MERGE/INSERT logic
+```
+
+<p align="center"><img src="docs/static/img/transform-dags.png" alt="Generated DAG" width="500"/></p>
+<p align="center"><i>The Airflow DAG above was generated from the SQL dependencies. Nobody wrote it.</i></p>
+
+## Why teams pick Starflow
+
+- **Config, not code**: YAML and plain SQL replace bespoke ETL scripts and orchestration glue.
+- **Any source, any warehouse, any orchestrator**: files, JDBC databases and Kafka into BigQuery, Snowflake, Redshift, DuckDB, PostgreSQL, Delta Lake or Iceberg, scheduled on Airflow, Dagster or Snowflake Tasks with generated DAGs.
+- **Quality and lineage built in**: expectations run at load time, and table- and column-level lineage falls out of your SQL automatically.
+- **Privacy by declaration**: column-level encryption, row- and column-level security policies applied from the same YAML.
+- **AI-assistant-ready**: MCP-based [Starlake Skills](https://github.com/starlake-ai/starlake-skills) teach Claude Code and GitHub Copilot to build and debug pipelines with you.
 
 ## Quick Start
 
@@ -51,23 +84,13 @@ Invoke-Expression (Invoke-WebRequest -Uri "https://raw.githubusercontent.com/sta
 docker run -it starlakeai/starlake:latest starlake bootstrap
 ```
 
-Then:
-```bash
-# Create a new project from a template
-starlake bootstrap
-
-# Load data
-starlake load
-
-# Run transformations
-starlake transform --name my_domain.my_table
-```
+> The product is Starflow; the CLI keeps its historical name `starlake`.
 
 For pre-built production-ready data stacks, see [Starlake Pragmatic Data Stacks](https://github.com/starlake-ai/starlake-data-stack).
 
-## How It Works
+## How it works
 
-<img src="docs/static/img/intent.png" alt="Starlake pipeline flow"/>
+<img src="docs/static/img/intent.png" alt="Starflow pipeline flow"/>
 
 ### 1. Extract
 
@@ -86,37 +109,12 @@ extract:
 
 ### 2. Load
 
-Define schemas, merge strategies, and data quality rules:
-
-```yaml
-table:
-  pattern: "salesorderdetail.*.psv"
-  metadata:
-    writeStrategy:
-      type: "UPSERT_BY_KEY_AND_TIMESTAMP"
-      timestamp: signup
-      key: [id]
-  attributes:
-    - name: "id"
-      type: "string"
-      required: true
-    - name: "signup"
-      type: "timestamp"
-```
+Point Starflow at your files: it infers schemas, validates every row against the declared types and expectations, and applies the merge strategy you declared. Malformed lines are quarantined into an audit trail and a replay file instead of failing the load.
 
 ### 3. Transform
 
-Write SQL, Starlake generates the correct MERGE/INSERT/OVERWRITE logic:
+Write plain SQL; Starflow wraps it in the correct MERGE/INSERT/OVERWRITE logic for your warehouse:
 
-```yaml
-transform:
-  tasks:
-    - name: most_profitable_products
-      writeStrategy:
-        type: "UPSERT_BY_KEY_AND_TIMESTAMP"
-        timestamp: signup
-        key: [id]
-```
 ```sql
 SELECT
   productid,
@@ -126,16 +124,25 @@ GROUP BY productid
 ORDER BY total_revenue DESC
 ```
 
+```yaml
+transform:
+  tasks:
+    - name: most_profitable_products
+      writeStrategy:
+        type: "UPSERT_BY_KEY_AND_TIMESTAMP"
+        timestamp: order_date
+        key: [productid]
+```
+
 ### 4. Orchestrate
 
-Starlake extracts SQL dependencies and generates DAGs automatically:
+Starflow extracts the dependencies between your loads and transforms and generates the DAGs:
 
 <p align="center"><img src="docs/static/img/transform-viz.svg" alt="Dependency graph" width="500"/></p>
-<p align="center"><img src="docs/static/img/transform-dags.png" alt="Generated DAG" width="500"/></p>
 
 Reference built-in templates for Airflow, Dagster, or Snowflake Tasks in your YAML. No custom DAG code required.
 
-## Supported Platforms
+## Supported platforms
 
 <p align="center">
   <img src="docs/static/img/data-star.png" alt="Supported platforms"/>
@@ -150,29 +157,18 @@ Reference built-in templates for Airflow, Dagster, or Snowflake Tasks in your YA
 | **Streaming** | Kafka |
 | **Cloud Storage** | GCS, S3, Azure Blob, HDFS, Local |
 
-## IDE & AI Support
+## IDE & AI support
 
-### VS Code Extension
+The [Starlake VS Code Extension](https://marketplace.visualstudio.com/items?itemName=Starlake.starlake) brings Starflow into your editor: schema inference, SQL transformations, ER diagrams, lineage visualization, and workflow orchestration without leaving VS Code.
 
-The [Starlake VS Code Extension](https://marketplace.visualstudio.com/items?itemName=Starlake.starlake) brings the full power of Starlake into your editor: schema inference, SQL transformations, ER diagrams, lineage visualization, and workflow orchestration, all without leaving VS Code.
+It ships with [Starlake Skills](https://github.com/starlake-ai/starlake-skills), MCP-based skills that give AI coding assistants like **Claude Code** and **GitHub Copilot** deep knowledge of the platform, so your assistant builds, debugs, and optimizes pipelines using Starflow best practices.
 
-### Starlake Skills
+## Community & documentation
 
-The extension ships with [Starlake Skills](https://github.com/starlake-ai/starlake-skills): MCP-based skills that supercharge AI coding assistants like **Claude Code** and **GitHub Copilot** with deep knowledge of the Starlake platform. Your AI assistant can help you build, debug, and optimize data pipelines using Starlake best practices.
-
-## Documentation
-
-Full documentation at **[docs.starlake.ai](https://docs.starlake.ai/)**
-
-- [Installation Guide](https://docs.starlake.ai/setup/starlake-core-setup)
-- [Concepts & Architecture](https://docs.starlake.ai/)
-- [Configuration Reference](https://docs.starlake.ai/)
-- [Contributing](https://docs.starlake.ai/devguide/contribute)
-
-## Contributing
-
-Contributions are welcome! See our [Contributing Guide](https://docs.starlake.ai/devguide/contribute) and [Code of Conduct](CODE_OF_CONDUCT.md).
+- **Discord**: questions, feedback and release news. [Join us](https://discord.com/invite/6tNa7yCNqw)
+- **Docs**: guides, concepts, and the full configuration reference at [docs.starlake.ai](https://docs.starlake.ai/)
+- **Contributing**: see the [Contributing Guide](https://docs.starlake.ai/devguide/contribute) and [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ## License
 
-Apache License 2.0 - see [LICENSE](LICENSE) for details.
+Apache License 2.0. See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -144,10 +144,6 @@ Reference built-in templates for Airflow, Dagster, or Snowflake Tasks in your YA
 
 ## Supported platforms
 
-<p align="center">
-  <img src="docs/static/img/data-star.png" alt="Supported platforms"/>
-</p>
-
 | Category | Supported |
 |---|---|
 | **Warehouses** | BigQuery, Snowflake, Redshift, DuckDB, PostgreSQL, Spark/Hive |

--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ For pre-built production-ready data stacks, see [Starlake Pragmatic Data Stacks]
 
 ## How it works
 
-<img src="docs/static/img/intent.png" alt="Starflow pipeline flow"/>
-
 ### 1. Extract
 
 Pull data from any JDBC source with a few lines of YAML:
@@ -136,11 +134,7 @@ transform:
 
 ### 4. Orchestrate
 
-Starflow extracts the dependencies between your loads and transforms and generates the DAGs:
-
-<p align="center"><img src="docs/static/img/transform-viz.svg" alt="Dependency graph" width="500"/></p>
-
-Reference built-in templates for Airflow, Dagster, or Snowflake Tasks in your YAML. No custom DAG code required.
+Starflow extracts the dependencies between your loads and transforms and generates the DAGs. Reference built-in templates for Airflow, Dagster, or Snowflake Tasks in your YAML. No custom DAG code required.
 
 ## Supported platforms
 

--- a/docs/superpowers/specs/2026-09-06-readme-restructure-design.md
+++ b/docs/superpowers/specs/2026-09-06-readme-restructure-design.md
@@ -1,0 +1,33 @@
+# README Restructure
+
+Date: 2026-09-06. Approved by Hayssam in session; implemented directly (single-file docs
+change, the section-by-section design below is the plan).
+
+## Goal
+
+Make the repository README more appealing: lead with proof instead of claims, adopt the
+Starflow-first branding (product Starflow, umbrella Starlake, binary `starlake`), and surface
+the community now that the team is on Discord.
+
+## Design (approach "Show, don't list")
+
+1. **Hero**: logo, `Starflow` as the product name, tagline "Declarative data pipelines by
+   Starlake". Badge row: build (test-only workflow, pull_request-scoped), release, license,
+   GitHub stars, Discord (static shield linking https://discord.com/invite/6tNa7yCNqw). Nav
+   row gains Discord.
+2. **Hook** (replaces the old opening paragraph): "Your warehouse, described, not scripted",
+   then the boilerplate-to-YAML promise in two sentences.
+3. **"A pipeline in 30 seconds"**: one self-explanatory load YAML (write strategy + semantic
+   type), the three CLI commands, and the generated-DAG image as payoff, captioned that no
+   DAG was written.
+4. **"Why teams pick Starflow"**: five outcome bullets (config-not-code; any source to any
+   warehouse to any orchestrator with generated DAGs; quality and lineage built in; privacy
+   controls; AI-assistant-ready via Starlake Skills).
+5. **Quick start**: unchanged installers; one-line note that the CLI keeps the historical
+   `starlake` name.
+6. **How it works**: existing 4-step walkthrough, YAML trimmed.
+7. **Platform matrix, IDE & AI**: kept, tightened.
+8. **Community & docs footer**: Discord prominent, docs, contributing, license.
+
+No new assets: reuses starlake-draw.png, intent.png, transform-viz.svg, transform-dags.png,
+data-star.png. Discord badge is a static shields.io badge (no server-id dependency).


### PR DESCRIPTION
## Summary
Full restructure per the approved design (committed at `docs/superpowers/specs/2026-09-06-readme-restructure-design.md`):

- **Hero**: Starflow as the product name ("by Starlake" umbrella), badge row extended with GitHub stars and Discord, nav gains Discord.
- **Hook**: "Your warehouse, described, not scripted."
- **A pipeline in 30 seconds**: one load YAML (write strategy + validation), the three CLI commands, and the generated-DAG image captioned "Nobody wrote it."
- **Why teams pick Starflow**: five outcome bullets replacing the eight feature bullets.
- Quick start unchanged, with a one-line note that the CLI keeps the historical `starlake` name; how-it-works tightened (Load step is now prose selling the reject/replay story); platform matrix and IDE/AI kept; community footer with the Discord invite.
- No new assets; every image already lives in `docs/static/img`.

Discord invite verified live (HTTP 200), stars/Discord badges render from shields.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7nDBiBJ6sPcqrkzp1pBg