### PR TITLE
ci: run test-only only when source can be affected

### DIFF
--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -8,6 +8,15 @@ on:
     branches:
       - master
       - branch-*
+    # Skip the ~90-minute test run for changes that cannot affect it: documentation,
+    # markdown anywhere, and the deployed setup.jar binary (rebuilt from sources that
+    # ARE covered). A PR touching any non-listed path still runs the full suite.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'CODE_OF_CONDUCT.md'
+      - 'distrib/setup.jar'
 
 jobs:
   snapshot:


### PR DESCRIPTION
Adds `paths-ignore` to the `test-only` pull_request trigger so docs-only PRs (`**.md`, `docs/**`, `LICENSE`) and the deployed `distrib/setup.jar` binary stop triggering the ~90-minute snapshot run. Today's README PRs each burned a full run for zero coverage. Any PR touching a non-ignored path still runs the whole suite, and `snapshot` is not a required status check, so the filter cannot leave a merge blocked waiting on a run that never starts.

Note the irony: this PR itself is workflow-only, so it still triggers the run one last time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc7nDBiBJ6sPcqrkzp1pBg